### PR TITLE
React-native debugging mode에서 reload할 때 NPE에러가 발생하는 현상 수정.

### DIFF
--- a/android/src/main/java/com/dooboolab/kakaologins/KakaoSDKAdapter.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/KakaoSDKAdapter.java
@@ -1,6 +1,5 @@
 package com.dooboolab.kakaologins;
 
-import android.app.Application;
 import android.content.Context;
 
 import com.kakao.auth.ApprovalType;

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -26,8 +26,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
-import com.facebook.react.bridge.UiThreadUtil;
-import com.kakao.auth.AccessTokenCallback;
 import com.kakao.auth.AuthType;
 import com.kakao.auth.ISessionCallback;
 import com.kakao.auth.KakaoSDK;
@@ -35,10 +33,8 @@ import com.kakao.auth.Session;
 import com.kakao.network.ErrorResult;
 import com.kakao.usermgmt.UserManagement;
 import com.kakao.usermgmt.callback.LogoutResponseCallback;
-import com.kakao.usermgmt.callback.MeResponseCallback;
 import com.kakao.usermgmt.callback.MeV2ResponseCallback;
 import com.kakao.usermgmt.response.MeV2Response;
-import com.kakao.usermgmt.response.model.UserProfile;
 import com.kakao.util.exception.KakaoException;
 import com.kakao.util.helper.log.Logger;
 
@@ -369,23 +365,19 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements A
 
   @Override
   public void onCatalystInstanceDestroy() {
-    Log.i("onInstanceDestroy","");
     super.onCatalystInstanceDestroy();
   }
 
   @Override
   public void onHostDestroy() {
-    Log.i("RNKakaoLogins", "onHostDestory");
-//    Session.getCurrentSession().removeCallback(this.callback);
+    Session.getCurrentSession().removeCallback(this.callback);
   }
 
   @Override
   public void onHostPause() {
-    Log.i("RNKakaoLogins", "onHostPause");
   }
 
   @Override
   public void onHostResume() {
-    Log.i("RNKakaoLogins", "onHostResume");
   }
 }


### PR DESCRIPTION
RN의 debugging 모드에서 reload할 때 NPE가 발생하는데. 정확히 무슨 현상인지는 알아내지는 못했고

----에러 로그 ----
>10-17 10:19:48.405 16498-16555/com.<packageName>E/AndroidRuntime: FATAL EXCEPTION: Thread-6
    Process: com.<packageName>, PID: 16498
    java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
        at java.lang.StringBuilder.<init>(StringBuilder.java:110)
        at com.facebook.react.devsupport.DevSupportManagerImpl$JSExceptionLogger.log(DevSupportManagerImpl.java:301)
        at com.facebook.react.devsupport.DevSupportManagerImpl.handleException(DevSupportManagerImpl.java:285)
        at com.facebook.react.ReactInstanceManager$5.run(ReactInstanceManager.java:942)
        at java.lang.Thread.run(Thread.java:761)
---------

reload가 요청되어 액티비티가 재생성 될 때의 시점과 KakaoSDK Adapter로 넘겨주는 application context의 생성 시점에 문제가 있는 걸로 판단하여 init()함수를 새로 만들었는데 정상적으로 reload가 되는 걸 확인했습니다.

componentWillMount()에서 KakaoLogin.init()을 하는 과정만 추가되면 됩니다.

검토해주시고 반영해주시면 감사하겠습니다.