### PR TITLE
Add birthday and gender to IProfile

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,8 @@ export interface IProfile {
   is_email_verified: boolean | null;
   is_kakaotalk_user: boolean | null;
   has_signed_up: boolean | null;
+  birthday: string | null;
+  gender: string | null;
 }
 
 /**


### PR DESCRIPTION
Related https://github.com/react-native-seoul/react-native-kakao-login/pull/102/files

getProfile 붙이다보니, IProfile에 birthday와 gender 없는걸 발견해서 요 부분 추가한것입니다.
gender 같은 경우 리터럴로 타입을 선언할까 하다가.. 카카오 공식 문서랑 넘겨온 값이 달라서 걍 `string` 으로 했습니다.
https://developers.kakao.com/docs/latest/ko/user-mgmt/common#gender
여기선 소문자로 male/female 이라고 적혀있지만
제가 받은 값은 MALE 이었거든요.