### PR TITLE
fix: no scopes handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,13 +233,13 @@ ex: `Xo8WBi6jzSxKDVR4drqm84yr9iU=`
 
 - version > 1.3.8
 
-|                         | iOS | Android |         type          |       Description       |
-| ----------------------- | :-: | :-----: | :-------------------: | :---------------------: |
-| `accessToken`           |  ✓  |    ✓    |       `string`        |          토큰           |
-| `refreshToken`          |  ✓  |    ✓    |       `string`        |      리프레쉬 토큰      |
-| `accessTokenExpiresAt`  |  ✓  |    ✓    | `yyyy-MM-ddThh:mm:ss` |     토큰 만료 시간      |
-| `refreshTokenExpiresAt` |  ✓  |    ✓    | `yyyy-MM-ddThh:mm:ss` | 리프레쉬 토큰 만료 시간 |
-| `scopes`                |  ✓  |         |      `string[]`       | 사용자로 부터 받은 권한 |
+|                         | iOS | Android |         type                    |       Description       |
+| ----------------------- | :-: | :-----: | :-----------------------------: | :---------------------: |
+| `accessToken`           |  ✓  |    ✓    |       `string`                  |          토큰           |
+| `refreshToken`          |  ✓  |    ✓    |       `string`                  |      리프레쉬 토큰      |
+| `accessTokenExpiresAt`  |  ✓  |    ✓    | `yyyy-MM-ddThh:mm:ss`           |     토큰 만료 시간      |
+| `refreshTokenExpiresAt` |  ✓  |    ✓    | `yyyy-MM-ddThh:mm:ss` or `null` | 리프레쉬 토큰 만료 시간, 구버전 SDK로 이미 로그인이 되어있었다면 null이 반환될 수 있습니다. |
+| `scopes`                |  ✓  |         |      `string[]`                 | 사용자로 부터 받은 권한 |
 
 - version <= 1.3.8
 

--- a/index.ts
+++ b/index.ts
@@ -8,14 +8,14 @@ export interface ICallback<T> {
 export interface ITokenInfo {
   accessTokenExpiresAt: string;
   refreshToken: string;
-  refreshTokenExpiresAt: string;
+  refreshTokenExpiresAt: string | null;
   accessToken: string;
   scopes?: string[]; // iOS only
 }
 
 export interface IProfile {
   id: string;
-  nickname: string;
+  nickname: string | null;
   profile_image_url: string | null;
   thumb_image_url: string | null;
   email: string | null;

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -89,7 +89,7 @@ RCT_EXPORT_METHOD(login:(RCTPromiseResolveBlock)resolve
                       @"refreshToken": session.token.refreshToken,
                       @"accessTokenExpiresAt": [formatter stringFromDate: session.token.accessTokenExpiresAt],
                       @"refreshTokenExpiresAt": session.token.refreshTokenExpiresAt != nil ? [formatter stringFromDate: session.token.refreshTokenExpiresAt] : [NSNull null],
-                      @"scopes": session.token.scopes});
+                      @"scopes": session.token.scopes != nil ? session.token.scopes : @[]});
         } else {
             RCTLogInfo(@"Error=%@", error);
             reject(getErrorCode(error), error.localizedDescription, error);
@@ -176,7 +176,7 @@ RCT_EXPORT_METHOD(updateScopes:(NSArray<NSString *>*) scopes
                               @"refreshToken": session.token.refreshToken,
                               @"accessTokenExpiresAt": [formatter stringFromDate: session.token.accessTokenExpiresAt],
                               @"refreshTokenExpiresAt": session.token.refreshTokenExpiresAt != nil ? [formatter stringFromDate: session.token.refreshTokenExpiresAt] : [NSNull null],
-                              @"scopes": session.token.scopes});
+                              @"scopes": session.token.scopes != nil ? session.token.scopes : @[]});
                 } else {
                     RCTLogInfo(@"Error=%@", error);
                     reject(getErrorCode(error), error.localizedDescription, error);

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -88,7 +88,7 @@ RCT_EXPORT_METHOD(login:(RCTPromiseResolveBlock)resolve
             resolve(@{@"accessToken": session.token.accessToken,
                       @"refreshToken": session.token.refreshToken,
                       @"accessTokenExpiresAt": [formatter stringFromDate: session.token.accessTokenExpiresAt],
-                      @"refreshTokenExpiresAt": [formatter stringFromDate: session.token.refreshTokenExpiresAt],
+                      @"refreshTokenExpiresAt": session.token.refreshTokenExpiresAt != nil ? [formatter stringFromDate: session.token.refreshTokenExpiresAt] : [NSNull null],
                       @"scopes": session.token.scopes});
         } else {
             RCTLogInfo(@"Error=%@", error);
@@ -175,7 +175,7 @@ RCT_EXPORT_METHOD(updateScopes:(NSArray<NSString *>*) scopes
                     resolve(@{@"accessToken": session.token.accessToken,
                               @"refreshToken": session.token.refreshToken,
                               @"accessTokenExpiresAt": [formatter stringFromDate: session.token.accessTokenExpiresAt],
-                              @"refreshTokenExpiresAt": [formatter stringFromDate: session.token.refreshTokenExpiresAt],
+                              @"refreshTokenExpiresAt": session.token.refreshTokenExpiresAt != nil ? [formatter stringFromDate: session.token.refreshTokenExpiresAt] : [NSNull null],
                               @"scopes": session.token.scopes});
                 } else {
                     RCTLogInfo(@"Error=%@", error);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26326015/87627670-2a65d900-c76a-11ea-8b88-3d26bbbc3596.png)
위의 스크린샷처럼 로그인 시점에서 동의 항목이 없을 때, 요청값들이 null 로 들어오는 경우에 대한 처리 작업입니다.

- [x] [Android] 동의 항목이 존재하지 않는 경우, `me.account` 및 `me.account.profile` 데이터가 null 로 들어오는 이슈 (may resolve #140)
- [x] [iOS] 동의 항목이 존재하지 않는 경우,`scopes` 가 nil 로 들어오는 이슈 (resolve #136 #143)
- [x] [iOS] 구버전 SDK에서 이미 세션을 생성(로그인) 한 상태에서 최신 SDK 로 업데이트 한 경우, `refreshTokenExpiresAt` 가 nil 로 들어오는 이슈
