### PR TITLE
Always add callbacks in onHostResume()

### DIFF
--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -461,9 +461,9 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements A
             KakaoSDK.init(new KakaoSDKAdapter(reactContext.getApplicationContext()));
             reactContext.addActivityEventListener(this);
             callback = new SessionCallback();
-            Session.getCurrentSession().addCallback(callback);
-            Session.getCurrentSession().checkAndImplicitOpen();
         }
+        Session.getCurrentSession().addCallback(callback);
+        Session.getCurrentSession().checkAndImplicitOpen();
     }
 
     public static String getLoginErrorCode(KakaoException exception) {


### PR DESCRIPTION
`onHostDestroy()` removes callbacks, so `onHostResume()` should always add them again, even if the Kakao SDK is already initialized.

Without this fix, if the app's main activity is destroyed and re-created (e.g, because the app went into the background temporarily), and the user tries to log in, then loginPromise will wait forever without resolving or rejecting.