### PR TITLE
[Feature] getTokens for getting accessToken and refreshToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,14 @@ ex: `Xo8WBi6jzSxKDVR4drqm84yr9iU=`
 
 #### Methods (callback is optional)
 
-| Func           |                  Param                   |     Return      | Description      |
-| :------------- | :--------------------------------------: | :-------------: | :--------------- |
-| login          | `callback? (err: Error, result: Object)` | Promise{Object} | 로그인           |
-| getProfile     | `callback? (err: Error, result: Object)` | Promise{Object} | 프로필 불러오기  |
-| logout         | `callback? (err: Error, result: String)` | Promise{String} | 로그아웃         |
-| unlink         | `callback? (err: Error, result: String)` | Promise{String} | 연결끊기         |
-| updateScopes   | `callback? (err: Error, result: String)` | Promise{Object} | 추가 권한 요청   |
-| getAccessToken | `callback? (err: Error, result: String)` | Promise{Object} | 액세스 토큰 조회 |
+| Func         |                  Param                   |     Return      | Description                     |
+| :----------- | :--------------------------------------: | :-------------: | :------------------------------ |
+| login        | `callback? (err: Error, result: Object)` | Promise{Object} | 로그인                          |
+| getProfile   | `callback? (err: Error, result: Object)` | Promise{Object} | 프로필 불러오기                 |
+| logout       | `callback? (err: Error, result: String)` | Promise{String} | 로그아웃                        |
+| unlink       | `callback? (err: Error, result: String)` | Promise{String} | 연결끊기                        |
+| updateScopes | `callback? (err: Error, result: String)` | Promise{Object} | 추가 권한 요청                  |
+| getTokens    | `callback? (err: Error, result: String)` | Promise{Object} | 액세스 토큰, 리프레시 토큰 조회 |
 
 #### params in result when `login` and `updateScopes`
 

--- a/README.md
+++ b/README.md
@@ -175,9 +175,23 @@ module.exports = {
    }
    ```
 
-6. Expo Kit을 사용하여 개발하는 경우 `RNKakaoLogin.xcodeproj`의 Build Settings => Header Search Paths에 `$(SRCROOT)/../../../ios/Pods/Headers/Public`를 `recursive`로 추가해주셔야 합니다.
+6. ios에서는 accessToken의 주기적인 갱신을 위해 [공식문서-토큰 관리](https://developers.kakao.com/docs/latest/ko/kakaologin/android#token-mgmt)를 참고하여 `AppDelegate.m` 파일에 아래와 같은 내용을 추가합니다.
 
-7. 잘 안되시면 Example Project를 확인하여 비교해보시면 되겠습니다.
+```
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    ...
+    [KOSession sharedSession].automaticPeriodicRefresh = YES;
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    ...
+    [KOSession handleDidEnterBackground];
+}
+```
+
+7. Expo Kit을 사용하여 개발하는 경우 `RNKakaoLogin.xcodeproj`의 Build Settings => Header Search Paths에 `$(SRCROOT)/../../../ios/Pods/Headers/Public`를 `recursive`로 추가해주셔야 합니다.
+
+8. 잘 안되시면 Example Project를 확인하여 비교해보시면 되겠습니다.
 
 #### Android
 
@@ -204,6 +218,7 @@ allprojects {
 </resources>
 ```
 
+5. [공식문서-토큰관리](https://developers.kakao.com/docs/latest/ko/kakaologin/android#token-mgmt) 에서 참고할 수 있듯이 Android 카카오 SDK는 액세스 토큰을 자동 갱신해줍니다.
 6. 컴파일 에러가 나면 `build.gradle`에서 android sdk compile version 등 빌드 sdk 버전을 맞춰주세요.
 7. 아래와 같은 에러가 발생할 경우 [키 해시 등록](https://developers.kakao.com/docs/latest/ko/getting-started/sdk-android-v1#key-hash)을 진행해주세요. 자바 코드로 구하는 방법이 제일 확실합니다.
 
@@ -247,6 +262,13 @@ ex: `Xo8WBi6jzSxKDVR4drqm84yr9iU=`
 |         | iOS | Android |   type   | Description |
 | ------- | :-: | :-----: | :------: | :---------: |
 | `token` |  ✓  |    ✓    | `string` |    토큰     |
+
+#### params in result when `getTokens`
+
+|                | iOS | Android |   type   |  Description  |
+| -------------- | :-: | :-----: | :------: | :-----------: |
+| `accessToken`  |  ✓  |    ✓    | `string` |  액세스 토큰  |
+| `refreshToken` |  ✓  |    ✓    | `string` | 리프레시 토큰 |
 
 #### params in result when `getProfile`
 

--- a/README.md
+++ b/README.md
@@ -221,25 +221,26 @@ ex: `Xo8WBi6jzSxKDVR4drqm84yr9iU=`
 
 #### Methods (callback is optional)
 
-| Func        |                  Param                   |     Return      | Description      |
-| :---------  | :--------------------------------------: | :-------------: | :--------------- |
-| login       | `callback? (err: Error, result: Object)` | Promise{Object} | 로그인          |
-| getProfile  | `callback? (err: Error, result: Object)` | Promise{Object} | 프로필 불러오기 |
-| logout      | `callback? (err: Error, result: String)` | Promise{String} | 로그아웃        |
-| unlink      | `callback? (err: Error, result: String)` | Promise{String} | 연결끊기        |
-| updateScopes| `callback? (err: Error, result: String)` | Promise{Object} | 추가 권한 요청   |
+| Func           |                  Param                   |     Return      | Description      |
+| :------------- | :--------------------------------------: | :-------------: | :--------------- |
+| login          | `callback? (err: Error, result: Object)` | Promise{Object} | 로그인           |
+| getProfile     | `callback? (err: Error, result: Object)` | Promise{Object} | 프로필 불러오기  |
+| logout         | `callback? (err: Error, result: String)` | Promise{String} | 로그아웃         |
+| unlink         | `callback? (err: Error, result: String)` | Promise{String} | 연결끊기         |
+| updateScopes   | `callback? (err: Error, result: String)` | Promise{Object} | 추가 권한 요청   |
+| getAccessToken | `callback? (err: Error, result: String)` | Promise{Object} | 액세스 토큰 조회 |
 
 #### params in result when `login` and `updateScopes`
 
 - version > 1.3.8
 
-|                         | iOS | Android |         type                    |       Description       |
-| ----------------------- | :-: | :-----: | :-----------------------------: | :---------------------: |
-| `accessToken`           |  ✓  |    ✓    |       `string`                  |          토큰           |
-| `refreshToken`          |  ✓  |    ✓    |       `string`                  |      리프레쉬 토큰      |
-| `accessTokenExpiresAt`  |  ✓  |    ✓    | `yyyy-MM-ddThh:mm:ss`           |     토큰 만료 시간      |
+|                         | iOS | Android |              type               |                                         Description                                         |
+| ----------------------- | :-: | :-----: | :-----------------------------: | :-----------------------------------------------------------------------------------------: |
+| `accessToken`           |  ✓  |    ✓    |            `string`             |                                            토큰                                             |
+| `refreshToken`          |  ✓  |    ✓    |            `string`             |                                        리프레쉬 토큰                                        |
+| `accessTokenExpiresAt`  |  ✓  |    ✓    |      `yyyy-MM-ddThh:mm:ss`      |                                       토큰 만료 시간                                        |
 | `refreshTokenExpiresAt` |  ✓  |    ✓    | `yyyy-MM-ddThh:mm:ss` or `null` | 리프레쉬 토큰 만료 시간, 구버전 SDK로 이미 로그인이 되어있었다면 null이 반환될 수 있습니다. |
-| `scopes`                |  ✓  |         |      `string[]`                 | 사용자로 부터 받은 권한 |
+| `scopes`                |  ✓  |         |           `string[]`            |                                   사용자로 부터 받은 권한                                   |
 
 - version <= 1.3.8
 

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -423,7 +423,7 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements A
     }
 
     @ReactMethod
-    private void getAccessToken(final Promise promise) {
+    private void getTokens(final Promise promise) {
         initKakaoSDK();
         AuthService.getInstance()
         .requestAccessTokenInfo(new ApiResponseCallback<AccessTokenInfoResponse>() {

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -439,7 +439,8 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements A
 
             @Override
             public void onSuccess(AccessTokenInfoResponse result) {
-                result.putString("accessToken", result.getAccessToken());
+                result.putString("accessToken", Session.getCurrentSession().getTokenInfo().getAccessToken());
+                result.putString("refreshToken", Session.getCurrentSession().getTokenInfo().getRefreshToken());
             }
         });
     }

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -422,6 +422,28 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements A
         });
     }
 
+    @ReactMethod
+    private void getAccessToken(final Promise promise) {
+        initKakaoSDK();
+        AuthService.getInstance()
+        .requestAccessTokenInfo(new ApiResponseCallback<AccessTokenInfoResponse>() {
+            @Override
+            public void onSessionClosed(ErrorResult errorResult) {
+                promise.reject(String.valueOf(errorResult.getErrorCode()), errorResult.getErrorMessage(), errorResult.getException());
+            }
+
+            @Override
+            public void onFailure(ErrorResult errorResult) {
+                promise.reject(String.valueOf(errorResult.getErrorCode()), errorResult.getErrorMessage(), errorResult.getException());
+            }
+
+            @Override
+            public void onSuccess(AccessTokenInfoResponse result) {
+                result.putString("accessToken", result.getAccessToken());
+            }
+        });
+    }
+
 
     public static class SessionCallback implements ISessionCallback {
         @Override

--- a/index.ts
+++ b/index.ts
@@ -195,7 +195,7 @@ export function updateScopes(
 
 export function getAccessToken(
   callback?: ICallback<{ accessToken: string }>
-): Promise<string> {
+): Promise<{ accessToken: string }> {
   return RNKakaoLogins.getAccessToken()
     .then((result) => {
       if (isFunction(callback)) {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules } from "react-native";
 const { RNKakaoLogins } = NativeModules;
 
 export interface ICallback<T> {
@@ -41,32 +41,32 @@ export interface IProfile {
  * */
 export enum KAKAO_ERROR {
   // SHARED
-  E_UNKNOWN = 'E_UNKNOWN',
-  E_CANCELLED_OPERATION = 'E_CANCELLED_OPERATION',
-  E_ILLEGAL_STATE = 'E_ILLEGAL_STATE',
+  E_UNKNOWN = "E_UNKNOWN",
+  E_CANCELLED_OPERATION = "E_CANCELLED_OPERATION",
+  E_ILLEGAL_STATE = "E_ILLEGAL_STATE",
 
   // IOS
-  E_IN_PROGRESS_OPERATION = 'E_IN_PROGRESS_OPERATION',
-  E_TOKEN_NOT_FOUND = 'E_TOKEN_NOT_FOUND',
-  E_DEACTIVATED_SESSION = 'E_DEACTIVATED_SESSION',
-  E_ALREADY_LOGINED = 'E_ALREADY_LOGINED',
-  E_HTTP_ERROR = 'E_HTTP_ERROR',
-  E_BAD_RESPONSE = 'E_BAD_RESPONSE',
-  E_NETWORK_ERROR = 'E_NETWORK_ERROR',
-  E_NOT_SUPPORTED = 'E_NOT_SUPPORTED',
-  E_BAD_PARAMETER = 'E_BAD_PARAMETER',
+  E_IN_PROGRESS_OPERATION = "E_IN_PROGRESS_OPERATION",
+  E_TOKEN_NOT_FOUND = "E_TOKEN_NOT_FOUND",
+  E_DEACTIVATED_SESSION = "E_DEACTIVATED_SESSION",
+  E_ALREADY_LOGINED = "E_ALREADY_LOGINED",
+  E_HTTP_ERROR = "E_HTTP_ERROR",
+  E_BAD_RESPONSE = "E_BAD_RESPONSE",
+  E_NETWORK_ERROR = "E_NETWORK_ERROR",
+  E_NOT_SUPPORTED = "E_NOT_SUPPORTED",
+  E_BAD_PARAMETER = "E_BAD_PARAMETER",
 
   // ANDROID
-  E_ILLEGAL_ARGUMENT = 'E_ILLEGAL_ARGUMENT',
-  E_MISS_CONFIGURATION = 'E_MISS_CONFIGURATION',
-  E_AUTHORIZATION_FAILED = 'E_AUTHORIZATION_FAILED',
-  E_JSON_PARSING_ERROR = 'E_JSON_PARSING_ERROR',
-  E_URI_LENGTH_EXCEEDED = 'E_URI_LENGTH_EXCEEDED',
-  E_KAKAOTALK_NOT_INSTALLED = 'E_KAKAOTALK_NOT_INSTALLED',
+  E_ILLEGAL_ARGUMENT = "E_ILLEGAL_ARGUMENT",
+  E_MISS_CONFIGURATION = "E_MISS_CONFIGURATION",
+  E_AUTHORIZATION_FAILED = "E_AUTHORIZATION_FAILED",
+  E_JSON_PARSING_ERROR = "E_JSON_PARSING_ERROR",
+  E_URI_LENGTH_EXCEEDED = "E_URI_LENGTH_EXCEEDED",
+  E_KAKAOTALK_NOT_INSTALLED = "E_KAKAOTALK_NOT_INSTALLED",
 }
 
 function isFunction(item): boolean {
-  return item ? typeof item === 'function' : false;
+  return item ? typeof item === "function" : false;
 }
 
 /**
@@ -79,8 +79,8 @@ export function login(callback?: ICallback<ITokenInfo>): Promise<ITokenInfo> {
     .then((result: ITokenInfo) => {
       const timeReFormattedResult = {
         ...result,
-        accessTokenExpiresAt: result.accessTokenExpiresAt.replace(' ', 'T'),
-        refreshTokenExpiresAt: result.refreshTokenExpiresAt.replace(' ', 'T'),
+        accessTokenExpiresAt: result.accessTokenExpiresAt.replace(" ", "T"),
+        refreshTokenExpiresAt: result.refreshTokenExpiresAt.replace(" ", "T"),
       };
       if (isFunction(callback)) {
         callback(null, timeReFormattedResult);
@@ -168,11 +168,14 @@ export function unlink(callback?: ICallback<string>): Promise<string> {
 
 /**
  * updateScopes
- * @param {Array<string>} scopes request scopes 
+ * @param {Array<string>} scopes request scopes
  * @param {ICallback<ITokenInfo>} [callback] callback function
  * @returns {Promise<ITokenInfo>}
  */
-export function updateScopes(scopes: Array<string>, callback?: ICallback<ITokenInfo>): Promise<ITokenInfo> {
+export function updateScopes(
+  scopes: Array<string>,
+  callback?: ICallback<ITokenInfo>
+): Promise<ITokenInfo> {
   return RNKakaoLogins.updateScopes(scopes)
     .then((result) => {
       if (isFunction(callback)) {
@@ -190,12 +193,31 @@ export function updateScopes(scopes: Array<string>, callback?: ICallback<ITokenI
     });
 }
 
+export function getAccessToken(
+  callback?: ICallback<{ accessToken: string }>
+): Promise<string> {
+  return RNKakaoLogins.getAccessToken()
+    .then((result) => {
+      if (isFunction(callback)) {
+        callback(null, result);
+      }
+      return result;
+    })
+    .catch((error) => {
+      if (isFunction(callback)) {
+        callback(error, null);
+      }
+      throw error;
+    });
+}
+
 const KakaoLogins = {
   login,
   logout,
   getProfile,
   unlink,
-  updateScopes
+  updateScopes,
+  getAccessToken,
 };
 
 export default KakaoLogins;

--- a/index.ts
+++ b/index.ts
@@ -193,10 +193,10 @@ export function updateScopes(
     });
 }
 
-export function getAccessToken(
-  callback?: ICallback<{ accessToken: string }>
-): Promise<{ accessToken: string }> {
-  return RNKakaoLogins.getAccessToken()
+export function getTokens(
+  callback?: ICallback<{ accessToken: string; refreshToken: string }>
+): Promise<{ accessToken: string; refreshToken: string }> {
+  return RNKakaoLogins.getTokens()
     .then((result) => {
       if (isFunction(callback)) {
         callback(null, result);
@@ -217,7 +217,7 @@ const KakaoLogins = {
   getProfile,
   unlink,
   updateScopes,
-  getAccessToken,
+  getTokens,
 };
 
 export default KakaoLogins;

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -194,7 +194,7 @@ RCT_EXPORT_METHOD(getAccessToken:(RCTPromiseResolveBlock)resolve
         RCTLogInfo(@"Error=%@", error);
         reject(getErrorCode(error), error.localizedDescription, error);
     } else {
-        resolve(@{@"accessToken": accessTokenInfo});
+        resolve(@{@"accessToken": accessTokenInfo.getAccessToken()});
     }
 }];
 }

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -189,13 +189,17 @@ RCT_EXPORT_METHOD(updateScopes:(NSArray<NSString *>*) scopes
 RCT_EXPORT_METHOD(getAccessToken:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
+    KOSession* session = [KOSession sharedSession];
+    
     [KOSessionTask accessTokenInfoTaskWithCompletionHandler:^(KOAccessTokenInfo *accessTokenInfo, NSError *error) {
-    if (error) {
-        RCTLogInfo(@"Error=%@", error);
-        reject(getErrorCode(error), error.localizedDescription, error);
-    } else {
-        resolve(@{@"accessToken": accessTokenInfo.getAccessToken()});
-    }
+        if (error) {
+            RCTLogInfo(@"Error=%@", error);
+            reject(getErrorCode(error), error.localizedDescription, error);
+        } else {
+            rsolve(@{@"accessToken": session.token.getAccessToken,
+                     @"refreshToken": session.token.refreshToken});
+        }
+    }];
 }];
 }
 

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -186,7 +186,7 @@ RCT_EXPORT_METHOD(updateScopes:(NSArray<NSString *>*) scopes
     }];
 }
 
-RCT_EXPORT_METHOD(getAccessToken:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(getTokens:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     KOSession* session = [KOSession sharedSession];
@@ -196,11 +196,10 @@ RCT_EXPORT_METHOD(getAccessToken:(RCTPromiseResolveBlock)resolve
             RCTLogInfo(@"Error=%@", error);
             reject(getErrorCode(error), error.localizedDescription, error);
         } else {
-            rsolve(@{@"accessToken": session.token.getAccessToken,
+            resolve(@{@"accessToken": session.token.accessToken,
                      @"refreshToken": session.token.refreshToken});
         }
     }];
-}];
 }
 
 @end

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -186,4 +186,17 @@ RCT_EXPORT_METHOD(updateScopes:(NSArray<NSString *>*) scopes
     }];
 }
 
+RCT_EXPORT_METHOD(updateScopes:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [KOSessionTask accessTokenInfoTaskWithCompletionHandler:^(KOAccessTokenInfo *accessTokenInfo, NSError *error) {
+    if (error) {
+        RCTLogInfo(@"Error=%@", error);
+        reject(getErrorCode(error), error.localizedDescription, error)
+    } else {
+        resolve(@{@"accessToken": accessTokenInfo})
+    }
+}];
+}
+
 @end

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -186,15 +186,15 @@ RCT_EXPORT_METHOD(updateScopes:(NSArray<NSString *>*) scopes
     }];
 }
 
-RCT_EXPORT_METHOD(updateScopes:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(getAccessToken:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     [KOSessionTask accessTokenInfoTaskWithCompletionHandler:^(KOAccessTokenInfo *accessTokenInfo, NSError *error) {
     if (error) {
         RCTLogInfo(@"Error=%@", error);
-        reject(getErrorCode(error), error.localizedDescription, error)
+        reject(getErrorCode(error), error.localizedDescription, error);
     } else {
-        resolve(@{@"accessToken": accessTokenInfo})
+        resolve(@{@"accessToken": accessTokenInfo});
     }
 }];
 }


### PR DESCRIPTION
로그인 된 유저의 accessToken 및 refreshToken을 가져오는 코드입니다. 
`react-native-kakao-login` 모듈로 로그인 한 후 REST API 등 accessToken을 이용한 편의성이 필요해 구현했습니다.

## Reference
01. [Android 공식 문서 - 토큰관리](https://developers.kakao.com/docs/latest/ko/kakaologin/android#token-mgmt)
02. [IOS 공식 문서 - 토큰관리](https://developers.kakao.com/docs/latest/ko/kakaologin/ios#token-mgmt)