### PR TITLE
연령대 연동 정보 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ ex: `Xo8WBi6jzSxKDVR4drqm84yr9iU=`
 | `gender`            |  ✓  |    ✓    |        성별        |
 | `birthday`          |  ✓  |    ✓    |        생일        |
 | `birthyear`         |  ✓  |    ✓    |      출생연도      |
+| `age_range`         |  ✓  |    ✓    |        연령대      |
 
-`email` / `gender` / `birthday` / `birthyear` / `phone_number` / `display_id` / `is_email_verified` / `is_kakaotalk_user` / `has_signed_up` <strong>해당 값들은 사용자의 동의 혹은 제휴를 통해 권한이 부여된 특정 앱에서만 획득할 수 있습니다. 권한이 있다면 그에 맞는 값을 리턴하고, 권한이 없다면 null 값을 반환합니다.</strong>
+`email` / `gender` / `birthday` / `birthyear` / `phone_number` / `display_id` / `is_email_verified` / `is_kakaotalk_user` / `has_signed_up` / `age_range` <strong>해당 값들은 사용자의 동의 혹은 제휴를 통해 권한이 부여된 특정 앱에서만 획득할 수 있습니다. 권한이 있다면 그에 맞는 값을 리턴하고, 권한이 없다면 null 값을 반환합니다.</strong>
 
 - version <= 1.3.8
 

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -174,6 +174,7 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements A
             profileMap.put("birthday", kakaoAccount.getBirthday());
             profileMap.put("display_id", kakaoAccount.getDisplayId());
             profileMap.put("phone_number", kakaoAccount.getPhoneNumber());
+            profileMap.put("age_range", kakaoAccount.getAgeRange().getValue());
         }
 
         return profileMap;
@@ -361,6 +362,7 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements A
                     profile.putString("birthday", nullableAccount.get("birthday"));
                     profile.putString("display_id", nullableAccount.get("display_id"));
                     profile.putString("phone_number", nullableAccount.get("phone_number"));
+                    profile.putString("age_range", nullableAccount.get("age_range"));
                     promise.resolve(profile);
                 } catch (Exception e) {
                     promise.reject("E_UNKOWN", e.getMessage(), e);

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ export interface IProfile {
   has_signed_up: boolean | null;
   birthday: string | null;
   gender: string | null;
+  age_range: string | null;
 }
 
 /**
@@ -168,7 +169,7 @@ export function unlink(callback?: ICallback<string>): Promise<string> {
 
 /**
  * updateScopes
- * @param {Array<string>} scopes request scopes 
+ * @param {Array<string>} scopes request scopes
  * @param {ICallback<ITokenInfo>} [callback] callback function
  * @returns {Promise<ITokenInfo>}
  */

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -133,7 +133,8 @@ RCT_EXPORT_METHOD(getProfile:(RCTPromiseResolveBlock)resolve
                 @"has_signed_up": handleKOBoolean(me.hasSignedUp),
                 @"gender": handleNullableEnumGender(me.account.gender),
                 @"birthday": handleNullableString(me.account.birthday),
-                @"birthyear": handleNullableString(me.account.birthyear)
+                @"birthyear": handleNullableString(me.account.birthyear),
+                @"age_range": handleNullableString(me.account.ageRange)
             };
 
             resolve(profile);
@@ -160,7 +161,7 @@ RCT_EXPORT_METHOD(updateScopes:(NSArray<NSString *>*) scopes
                   rejecter:(RCTPromiseRejectBlock) reject)
 {
     KOSession* session = [KOSession sharedSession];
-    
+
     [session updateScopes: scopes
         completionHandler: ^(NSError *error) {
         if (error) {

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -41,34 +41,34 @@ NSObject* handleNullableEnumGender(KOUserGender gender)
 NSObject* handleNullableEnumAgeRange(KOUserAgeRange ageRange)
 {
     if (ageRange == KOUserAgeRangeType0) {
-        return @"0세~9세";
+        return @"0~9";
     }
     if (ageRange == KOUserAgeRangeType10 ) {
-        return @"10세~14세";
+        return @"10~14";
     }
     if (ageRange == KOUserAgeRangeType15 ) {
-        return @"15세~19세";
+        return @"15~19";
     }
     if (ageRange == KOUserAgeRangeType20 ) {
-        return @"20세~29세";
+        return @"20~29";
     }
     if (ageRange == KOUserAgeRangeType30 ) {
-        return @"30세~39세";
+        return @"30~39";
     }
     if (ageRange == KOUserAgeRangeType40 ) {
-        return @"40세~49세";
+        return @"40~49";
     }
     if (ageRange == KOUserAgeRangeType50 ) {
-        return @"50세~59세";
+        return @"50~59";
     }
     if (ageRange == KOUserAgeRangeType60 ) {
-        return @"60세~69세";
+        return @"60~69";
     }
     if (ageRange == KOUserAgeRangeType70 ) {
-        return @"70~79세";
+        return @"70~79";
     }
     if (ageRange == KOUserAgeRangeType80 ) {
-        return @"80세~89세";
+        return @"80~89";
     }
     if (ageRange == KOUserAgeRangeType90 ) {
         return @"90세 이상";

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -71,7 +71,7 @@ NSObject* handleNullableEnumAgeRange(KOUserAgeRange ageRange)
         return @"80~89";
     }
     if (ageRange == KOUserAgeRangeType90 ) {
-        return @"90세 이상";
+        return @"90";
     }
     return [NSNull null];
 }

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -38,6 +38,44 @@ NSObject* handleNullableEnumGender(KOUserGender gender)
     return [NSNull null];
 }
 
+NSObject* handleNullableEnumAgeRange(KOUserAgeRange ageRange)
+{
+    if (ageRange == KOUserAgeRangeType0) {
+        return @"0세~9세";
+    }
+    if (ageRange == KOUserAgeRangeType10 ) {
+        return @"10세~14세";
+    }
+    if (ageRange == KOUserAgeRangeType15 ) {
+        return @"15세~19세";
+    }
+    if (ageRange == KOUserAgeRangeType20 ) {
+        return @"20세~29세";
+    }
+    if (ageRange == KOUserAgeRangeType30 ) {
+        return @"30세~39세";
+    }
+    if (ageRange == KOUserAgeRangeType40 ) {
+        return @"40세~49세";
+    }
+    if (ageRange == KOUserAgeRangeType50 ) {
+        return @"50세~59세";
+    }
+    if (ageRange == KOUserAgeRangeType60 ) {
+        return @"60세~69세";
+    }
+    if (ageRange == KOUserAgeRangeType70 ) {
+        return @"70~79세";
+    }
+    if (ageRange == KOUserAgeRangeType80 ) {
+        return @"80세~89세";
+    }
+    if (ageRange == KOUserAgeRangeType90 ) {
+        return @"90세 이상";
+    }
+    return [NSNull null];
+}
+
 NSString* getErrorCode(NSError *error){
     int errorCode = (int)error.code;
 
@@ -134,7 +172,7 @@ RCT_EXPORT_METHOD(getProfile:(RCTPromiseResolveBlock)resolve
                 @"gender": handleNullableEnumGender(me.account.gender),
                 @"birthday": handleNullableString(me.account.birthday),
                 @"birthyear": handleNullableString(me.account.birthyear),
-                @"age_range": handleNullableString(me.account.ageRange)
+                @"age_range": handleNullableEnumAgeRange(me.account.ageRange)
             };
 
             resolve(profile);


### PR DESCRIPTION
biz사용자 등록 후, 연령대 연동 정보 추가
- 안드로이드와 iOS 동일한 형태로 리턴되도록 수정
- 리턴값
  - 0~9
  - 10~14
  - 15~19
  - ...
  - 80~89
  - 90


[안드로이드 enum](https://developers.kakao.com/sdk/reference/android-legacy/release/index.html?com/kakao/usermgmt/response/model/UserAccount.html)
[iOS enum](https://developers.kakao.com/sdk/reference/ios-legacy/release/Constants/KOUserAgeRange.html)