### PR TITLE
login메서드에 인증 방법 선택 옵션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ ex: `Xo8WBi6jzSxKDVR4drqm84yr9iU=`
 
 #### Methods (callback is optional)
 
-| Func         |                  Param                   |     Return      | Description                     |
-| :----------- | :--------------------------------------: | :-------------: | :------------------------------ |
-| login        | `callback? (err: Error, result: Object)` | Promise{Object} | 로그인                          |
-| getProfile   | `callback? (err: Error, result: Object)` | Promise{Object} | 프로필 불러오기                 |
-| logout       | `callback? (err: Error, result: String)` | Promise{String} | 로그아웃                        |
-| unlink       | `callback? (err: Error, result: String)` | Promise{String} | 연결끊기                        |
-| updateScopes | `callback? (err: Error, result: String)` | Promise{Object} | 추가 권한 요청                  |
-| getTokens    | `callback? (err: Error, result: String)` | Promise{Object} | 액세스 토큰, 리프레시 토큰 조회 |
+| Func         |                                       Param                                     |     Return      | Description                |
+| :----------- | :-----------------------------------------------------------------------------: | :-------------: | :--------------------------|
+| login        |  `callback? (err: Error, result: Object)` `authTypes? Array<KAKAO_AUTH_TYPES>`  | Promise{Object} | 로그인                       |
+| getProfile   |                     `callback? (err: Error, result: Object)`                    | Promise{Object} | 프로필 불러오기                |
+| logout       |                     `callback? (err: Error, result: String)`                    | Promise{String} | 로그아웃                     |
+| unlink       |                     `callback? (err: Error, result: String)`                    | Promise{String} | 연결끊기                     |
+| updateScopes |                     `callback? (err: Error, result: String)`                    | Promise{Object} | 추가 권한 요청                |
+| getTokens    |                     `callback? (err: Error, result: String)`                    | Promise{Object} | 액세스 토큰, 리프레시 토큰 조회   |
 
 #### params in result when `login` and `updateScopes`
 
@@ -347,6 +347,18 @@ E_AUTHORIZATION_FAILED;
 E_JSON_PARSING_ERROR;
 E_URI_LENGTH_EXCEEDED;
 E_KAKAOTALK_NOT_INSTALLED;
+```
+
+#### Authorization method selection support
+
+> `login` 메서드 호출 시, 사용할 인증 수단을 선택할 수 있습니다.
+
+```js
+// 카카오톡으로 바로 인증합니다 (미설치시 카카오 계정 로그인)
+KakaoLogins.login(undefined, [KAKAO_AUTH_TYPES.Talk]);
+
+// 카카오톡 또는 카카오 계정 로그인을 유저가 선택하도록 합니다
+KakaoLogins.login(undefined, [KAKAO_AUTH_TYPES.Talk, KAKAO_AUTH_TYPES.Account]);
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ ex: `Xo8WBi6jzSxKDVR4drqm84yr9iU=`
 
 | Func         |                                       Param                                     |     Return      | Description                |
 | :----------- | :-----------------------------------------------------------------------------: | :-------------: | :--------------------------|
-| login        |  `callback? (err: Error, result: Object)` `authTypes? Array<KAKAO_AUTH_TYPES>`  | Promise{Object} | 로그인                       |
+| login        |  `authTypes? Array<KAKAO_AUTH_TYPES>` `callback? (err: Error, result: Object)`  | Promise{Object} | 로그인                       |
 | getProfile   |                     `callback? (err: Error, result: Object)`                    | Promise{Object} | 프로필 불러오기                |
 | logout       |                     `callback? (err: Error, result: String)`                    | Promise{String} | 로그아웃                     |
 | unlink       |                     `callback? (err: Error, result: String)`                    | Promise{String} | 연결끊기                     |
@@ -355,10 +355,10 @@ E_KAKAOTALK_NOT_INSTALLED;
 
 ```js
 // 카카오톡으로 바로 인증합니다 (미설치시 카카오 계정 로그인)
-KakaoLogins.login(undefined, [KAKAO_AUTH_TYPES.Talk]);
+KakaoLogins.login([KAKAO_AUTH_TYPES.Talk]);
 
 // 카카오톡 또는 카카오 계정 로그인을 유저가 선택하도록 합니다
-KakaoLogins.login(undefined, [KAKAO_AUTH_TYPES.Talk, KAKAO_AUTH_TYPES.Account]);
+KakaoLogins.login([KAKAO_AUTH_TYPES.Talk, KAKAO_AUTH_TYPES.Account]);
 ```
 
 ## Usage

--- a/index.ts
+++ b/index.ts
@@ -90,8 +90,8 @@ function isFunction(item): boolean {
  * @returns {Promise<ITokenInfo>}
  */
 export function login(
-  callback?: ICallback<ITokenInfo>,
-  authTypes?: Array<KAKAO_AUTH_TYPES>
+  authTypes?: Array<KAKAO_AUTH_TYPES>,
+  callback?: ICallback<ITokenInfo>
 ): Promise<ITokenInfo> {
   const authTypesWithDefault = authTypes || [];
   return RNKakaoLogins.login(authTypesWithDefault)

--- a/index.ts
+++ b/index.ts
@@ -93,7 +93,8 @@ export function login(
   callback?: ICallback<ITokenInfo>,
   authTypes?: Array<KAKAO_AUTH_TYPES>
 ): Promise<ITokenInfo> {
-  return RNKakaoLogins.login(authTypes)
+  const authTypesWithDefault = authTypes || [];
+  return RNKakaoLogins.login(authTypesWithDefault)
     .then((result: ITokenInfo) => {
       const timeReFormattedResult = {
         ...result,

--- a/index.ts
+++ b/index.ts
@@ -86,10 +86,14 @@ function isFunction(item): boolean {
 /**
  * login
  * @param {ICallback<ITokenInfo>} [callback] callback function
+ * @param {Array<KAKAO_AUTH_TYPES>} authTypes authorization methods array
  * @returns {Promise<ITokenInfo>}
  */
-export function login(callback?: ICallback<ITokenInfo>): Promise<ITokenInfo> {
-  return RNKakaoLogins.login()
+export function login(
+  callback?: ICallback<ITokenInfo>,
+  authTypes?: Array<KAKAO_AUTH_TYPES>
+): Promise<ITokenInfo> {
+  return RNKakaoLogins.login(authTypes)
     .then((result: ITokenInfo) => {
       const timeReFormattedResult = {
         ...result,

--- a/index.ts
+++ b/index.ts
@@ -66,6 +66,19 @@ export enum KAKAO_ERROR {
   E_KAKAOTALK_NOT_INSTALLED = "E_KAKAOTALK_NOT_INSTALLED",
 }
 
+/**
+ * KAKAO_AUTH_TYPES 인증 수단
+ * iOS 기준의 값이며, Android도 지원합니다
+ *
+ * @url Android : https://developers.kakao.com/sdk/reference/android-legacy/release/index.html
+ * @url iOS     : https://developers.kakao.com/sdk/reference/ios-legacy/release/Constants/KOAuthType.html
+ */
+export enum KAKAO_AUTH_TYPES {
+  Talk = 2,
+  Story = 4,
+  Account = 8,
+}
+
 function isFunction(item): boolean {
   return item ? typeof item === "function" : false;
 }

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -112,7 +112,8 @@ NSString* getErrorCode(NSError *error){
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(login:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(login:(nullable NSArray<NSNumber *> *)authTypes
+                  resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     KOSession *session = [KOSession sharedSession];
@@ -132,7 +133,7 @@ RCT_EXPORT_METHOD(login:(RCTPromiseResolveBlock)resolve
             RCTLogInfo(@"Error=%@", error);
             reject(getErrorCode(error), error.localizedDescription, error);
         }
-    }];
+    } authTypes:authTypes];
 }
 
 RCT_EXPORT_METHOD(logout:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
인증 수단을 선택하는 화면에서 유저가 로그인/가입 중 이탈할 가능성을 줄이고
유저의 기기에 설치된 카카오 앱을 카카오 계정보다 인증 수단으로써 우선할 수 있도록 하기 위해
PR을 작성하게 되었습니다 :)

작성한 코드에 대해 피드백 주시면 적극 반영하도록 하겠습니다.

좋은 모듈 만들어주셔서 감사합니다!


Fixes #133 
