### PR TITLE
react-native-kakao-login index file 확장자 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@react-native-seoul/kakao-login",
   "version": "3.0.6",
   "description": "React Native Module for Kakao Login",
-  "main": "index.js",
+  "main": "index.ts",
   "types": "index.d.ts",
   "postinstall": "dooboolab-welcome postinstall",
   "scripts": {


### PR DESCRIPTION
안녕하세요!


```
error: Error: While trying to resolve module `@react-native-seoul/kakao-login` 
from file `/react-native-kakao-login/KakaoLoginExample/src/components/pages/Intro.tsx`, 
the package `/react-native-kakao-login/KakaoLoginExample/node_modules/@react-native-seoul/kakao-login/package.json` was successfully found. 

However, this package itself specifies a `main` module field that could not be resolved 
(`react-native-kakao-login/KakaoLoginExample/node_modules/@react-native-seoul/kakao-login/index.js`.
```

해당 에러가 발생하여, 상단의 entry file 확장자 변경하여 PR 올립니다. 
좋은 라이브러리 만들어주셔서 감사합니다! :)