### PR TITLE
`KakaoProfile.id` 타입을 `string`에서 `number`로 정정합니다.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@ export type KakaoAccessTokenInfo = {
 };
 
 export type KakaoProfile = {
-  id: string;
+  id: number;
   email: string;
   nickname: string;
   profileImageUrl: string;


### PR DESCRIPTION
최신 버전에서 `string`이 아닌 `number`가 반환되고 있습니다. 타입 선언을 이에 맞게 정정합니다.