### PR TITLE
잘못된 `KakaoProfile` 타입의 필드 이름을 변경합니다(`birthDay` -> `birthday`).

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ export type KakaoProfile = {
   thumbnailImageUrl: string;
   phoneNumber: string;
   ageRange: string;
-  birthDay: string;
+  birthday: string;
   birthdayType: string;
   birthyear: string;
   gender: string;


### PR DESCRIPTION
실제로 구현된 필드 이름과 다릅니다.