### PR TITLE
Refactor build configs (build.gradle, Podfile)

### DIFF
--- a/KakaoLoginExample/ios/KakaoLoginExample.xcodeproj/project.pbxproj
+++ b/KakaoLoginExample/ios/KakaoLoginExample.xcodeproj/project.pbxproj
@@ -572,7 +572,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -637,7 +637,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/KakaoLoginExample/ios/Podfile
+++ b/KakaoLoginExample/ios/Podfile
@@ -3,8 +3,6 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 platform :ios, '11.0'
 
-# $KakaoSDKVersion = "2.9.0"
-
 target 'KakaoLoginExample' do
   config = use_native_modules!
 

--- a/KakaoLoginExample/ios/Podfile
+++ b/KakaoLoginExample/ios/Podfile
@@ -3,6 +3,8 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 platform :ios, '11.0'
 
+# $KakaoSDKVersion = "2.9.0"
+
 target 'KakaoLoginExample' do
   config = use_native_modules!
 

--- a/KakaoLoginExample/ios/Podfile.lock
+++ b/KakaoLoginExample/ios/Podfile.lock
@@ -58,12 +58,12 @@ PODS:
     - FlipperKit/Core
     - FlipperKit/FlipperKitNetworkPlugin
   - glog (0.3.5)
-  - kakao-login (3.4.3):
-    - KakaoSDK (~> 2.9.0)
-    - KakaoSDKAuth (~> 2.9.0)
-    - KakaoSDKCommon (~> 2.9.0)
-    - KakaoSDKTalk (~> 2.9.0)
-    - KakaoSDKUser (~> 2.9.0)
+  - kakao-login (4.0.0):
+    - KakaoSDK (= 2.9.0)
+    - KakaoSDKAuth (= 2.9.0)
+    - KakaoSDKCommon (= 2.9.0)
+    - KakaoSDKTalk (= 2.9.0)
+    - KakaoSDKUser (= 2.9.0)
     - React
   - KakaoSDK (2.9.0):
     - KakaoSDKAuth (= 2.9.0)
@@ -565,7 +565,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 05e635f9366205191c9f1e0158c752f30d37ca90
+  FBReactNativeSpec: e87117337f49d2178fe109bb2453cea6bcef55fc
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -574,7 +574,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 602921fee03edacf18f5d6f3d3594ba477f456e5
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  kakao-login: 099175b2e23620a10bb6375860854034bb92ca44
+  kakao-login: a94950a55bea6a1a182f6207a6e032f3cc5996f3
   KakaoSDK: d5a5a38ebf4da97beeecf100ac3dc9a020e19648
   KakaoSDKAuth: 5d9eec3317320dc60015ba8d597b2ad32fc70b1a
   KakaoSDKCommon: aaed06bb779b92cd6f5c35e94160d4ecfaaac511
@@ -621,4 +621,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: da9820c880bcf2e846a670ea8dc0c73c7822fc97
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
 
 6. Project => Targets 아래 앱 선택 => General 탭으로 이동해서 Bundle Identifier가 본인의 카카오 앱과 동일한지 확인해주세요.
 
+7. 여러 라이브러리에서 동일한 버전의 SDK를 써야 하는 경우 `Podfile`에 아래와 같이 추가하여 SDK 버전을 강제로 지정할 수 있습니다.
+
+   ```ruby
+   # 없는 경우에는 package.json의 sdkVersions.ios.kakao를 따릅니다.
+   $KakaoSDKVersion=YOUR_KAKAO_SDK_VERSION 
+   ```
+
 #### Android
 
 1. [키 해시 등록](https://developers.kakao.com/docs/latest/ko/getting-started/sdk-android-v1#key-hash)을 진행해주세요. 자바 코드로 구하는 방법이 제일 확실합니다.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
   repositories {
     google()
     mavenCentral()
-    jcenter()
 
     maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
   }
@@ -57,7 +56,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,60 +1,144 @@
 buildscript {
-    ext {
-        gradleVersion = '4.1.0'
-        kotlinVersion = '1.3.41'
-    }
+  // Buildscript is evaluated before everything else so we can't use getExtOrDefault
+  def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNKakaoLogins_kotlinVersion']
+  def gradle_version = rootProject.ext.has('gradleVersion') ? rootProject.ext.get('gradleVersion') : project.properties['RNKakaoLogins_gradleVersion']
 
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    mavenCentral()
+    jcenter()
 
-    dependencies {
-        classpath("com.android.tools.build:gradle:$gradleVersion")
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-    }
-}
+    maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
+  }
 
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  dependencies {
+    classpath "com.android.tools.build:gradle:$gradle_version"
+    // noinspection DifferentKotlinGradleVersion
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+def getExtOrDefault(name) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['RNKakaoLogins_' + name]
+}
+
+def getExtOrIntegerDefault(name) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['RNKakaoLogins_' + name]).toInteger()
+}
+
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 29)
-
-    defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 19)
-        targetSdkVersion safeExtGet('targetSdkVersion', 29)
-        versionCode 1
-        versionName "1.0"
+  compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+    versionCode 1
+    versionName "1.0"
+  }
+  buildTypes {
+    release {
+      minifyEnabled false
     }
+  }
+  lintOptions {
+    disable 'GradleCompatible'
+  }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 
-    lintOptions {
-        abortOnError false
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 repositories {
-    maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
+  mavenCentral()
+  jcenter()
+  google()
+
+  maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
+
+
+  def found = false
+  def defaultDir = null
+  def androidSourcesName = 'React Native sources'
+
+  if (rootProject.ext.has('reactNativeAndroidRoot')) {
+    defaultDir = rootProject.ext.get('reactNativeAndroidRoot')
+  } else {
+    defaultDir = new File(
+            projectDir,
+            '/../../../node_modules/react-native/android'
+    )
+  }
+
+  if (defaultDir.exists()) {
+    maven {
+      url defaultDir.toString()
+      name androidSourcesName
+    }
+
+    logger.info(":${project.name}:reactNativeAndroidRoot ${defaultDir.canonicalPath}")
+    found = true
+  } else {
+    def parentDir = rootProject.projectDir
+
+    1.upto(5, {
+      if (found) return true
+      parentDir = parentDir.parentFile
+
+      def androidSourcesDir = new File(
+              parentDir,
+              'node_modules/react-native'
+      )
+
+      def androidPrebuiltBinaryDir = new File(
+              parentDir,
+              'node_modules/react-native/android'
+      )
+
+      if (androidPrebuiltBinaryDir.exists()) {
+        maven {
+          url androidPrebuiltBinaryDir.toString()
+          name androidSourcesName
+        }
+
+        logger.info(":${project.name}:reactNativeAndroidRoot ${androidPrebuiltBinaryDir.canonicalPath}")
+        found = true
+      } else if (androidSourcesDir.exists()) {
+        maven {
+          url androidSourcesDir.toString()
+          name androidSourcesName
+        }
+
+        logger.info(":${project.name}:reactNativeAndroidRoot ${androidSourcesDir.canonicalPath}")
+        found = true
+      }
+    })
+  }
+
+  if (!found) {
+    throw new GradleException(
+            "${project.name}: unable to locate React Native android sources. " +
+                    "Ensure you have you installed React Native as a dependency in your project and try again."
+    )
+  }
 }
 
+def kotlin_version = getExtOrDefault('kotlinVersion')
+def kakao_sdk_version = getExtOrDefault('kakaoSdkVersion')
+
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${project.ext.kotlinVersion}"
-    implementation "com.kakao.sdk:v2-user:2.9.0"
-    implementation "com.kakao.sdk:v2-talk:2.9.0"
-    implementation "com.kakao.sdk:v2-story:2.9.0"
+  // noinspection GradleDynamicVersion
+  api 'com.facebook.react:react-native:+'
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+  // Kakao
+  implementation "com.kakao.sdk:v2-user:$kakao_sdk_version" // 카카오 로그인
+  implementation "com.kakao.sdk:v2-talk:$kakao_sdk_version" // 친구, 메시지(카카오톡)
+  implementation "com.kakao.sdk:v2-story:$kakao_sdk_version" // 카카오 스토리
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,5 @@
+KakaoLogins_kotlinVersion=1.3.50
+KakaoLogins_compileSdkVersion=31
+KakaoLogins_targetSdkVersion=31
+KakaoLogins_kakaoSdkVersion=2.9.1
+KakaoLogins_gradleVersion=4.1.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
-KakaoLogins_kotlinVersion=1.3.50
-KakaoLogins_compileSdkVersion=31
-KakaoLogins_targetSdkVersion=31
-KakaoLogins_kakaoSdkVersion=2.9.1
-KakaoLogins_gradleVersion=4.1.0
+RNKakaoLogins_kotlinVersion=1.3.50
+RNKakaoLogins_compileSdkVersion=31
+RNKakaoLogins_targetSdkVersion=31
+RNKakaoLogins_kakaoSdkVersion=2.9.1
+RNKakaoLogins_gradleVersion=4.1.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 RNKakaoLogins_kotlinVersion=1.3.50
 RNKakaoLogins_compileSdkVersion=31
 RNKakaoLogins_targetSdkVersion=31
-RNKakaoLogins_kakaoSdkVersion=2.9.1
+RNKakaoLogins_kakaoSdkVersion=2.9.0
 RNKakaoLogins_gradleVersion=4.1.0

--- a/kakao-login.podspec
+++ b/kakao-login.podspec
@@ -3,7 +3,7 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-kakao_sdk_version = package['sdkVersions']['ios']['kakao']
+kakao_sdk_version = "2.9.0"
 
 Pod::Spec.new do |s|
   s.name         = "kakao-login"

--- a/kakao-login.podspec
+++ b/kakao-login.podspec
@@ -3,6 +3,7 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+kakao_sdk_version = package['sdkVersions']['ios']['kakao']
 
 Pod::Spec.new do |s|
   s.name         = "kakao-login"
@@ -26,10 +27,15 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
 
-  s.dependency 'KakaoSDK', '~> 2.9.0'
-  s.dependency 'KakaoSDKCommon', '~> 2.9.0'
-  s.dependency 'KakaoSDKAuth', '~> 2.9.0'
-  s.dependency 'KakaoSDKUser', '~> 2.9.0'
-  s.dependency 'KakaoSDKTalk', '~> 2.9.0'
+  if defined?($KakaoSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Kakao SDK version '#{$KakaoSDKVersion}'"
+    kakao_sdk_version = $KakaoSDKVersion
+  end
+
+  s.dependency 'KakaoSDK', kakao_sdk_version
+  s.dependency 'KakaoSDKCommon',  kakao_sdk_version
+  s.dependency 'KakaoSDKAuth',  kakao_sdk_version
+  s.dependency 'KakaoSDKUser', kakao_sdk_version
+  s.dependency 'KakaoSDKTalk', kakao_sdk_version
 end
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
     "react": "*",
     "react-native": "*"
   },
+  "sdkVersions": {
+    "ios": {
+      "kakao": "2.9.1"
+    },
+    "android": {
+      "kakao": "2.9.1"
+    }
+  },
   "dependencies": {
     "dooboolab-welcome": "^1.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -33,14 +33,6 @@
     "react": "*",
     "react-native": "*"
   },
-  "sdkVersions": {
-    "ios": {
-      "kakao": "2.9.1"
-    },
-    "android": {
-      "kakao": "2.9.1"
-    }
-  },
   "dependencies": {
     "dooboolab-welcome": "^1.3.2"
   },


### PR DESCRIPTION
## AS-IS

기존에 쓰고 있는 다른 라이브러리의 kakao sdk나 build tool (ex. gradle tools) 의 버전과 mismatch 되어 빌드에 문제 발생.

## Solution

- [create-react-native-library](https://github.com/callstack/react-native-builder-bob/tree/main/packages/create-react-native-library/templates) 의 템플릿을 참고로 하여 root project의 `kotlinVersion`, `compileSdkVersion`, `targetSdkVersion`, `gradleVersion` 등을 우선적으로 바라보도록 `build.gradle` 수정
- [RNFirebase의 서브 프로젝트](https://github.com/invertase/react-native-firebase/tree/main/packages) Podfile 버전 참조 방식을 참고로 하여, Podfile에 `$KakaoSDKVersion` 추가 및 `package.json`에 지정된 값을 먼저 가져오도록 수정


## TO-BE

1. Android: rootProject의 환경변수를 먼저 가져오고 fallback으로 `gradle.properties`에 지정된 값을 기본값으로 사용.
2. iOS: ~~package.json에 설정된 `sdkVersions.ios.kakao` 의 버전을 기본으로 가져오되,~~ `$KakaoSDKVersion`이 `Podfile`에 지정된 경우 이를 우선 사용 함. (`$KakaoSDKVersion`은 호환성을 체크하고 신중히 사용 하셔야 합니다.) -> podfile에 `kakao_sdk_version`을 사용합니다.
3. ~~kakaoSDKs version: 2.9.0 -> 2.9.1 bump~~
