### PR TITLE
feat(android): improve installation step

### DIFF
--- a/KakaoLoginExample/android/build.gradle
+++ b/KakaoLoginExample/android/build.gradle
@@ -21,6 +21,17 @@ buildscript {
     }
 }
 
+// Example: SDK version set to 2.10.0
+//project.ext {
+//    set('react-native', [
+//        versions: [
+//            kakao: [
+//                sdk: "2.10.0"
+//            ]
+//        ]
+//    ])
+//}
+
 allprojects {
     repositories {
         mavenLocal()
@@ -28,7 +39,6 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
         }
-        maven { url 'http://devrepo.kakao.com:8088/nexus/content/groups/public/' }
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")

--- a/KakaoLoginExample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/KakaoLoginExample/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
    # 없는 경우에는 package.json의 sdkVersions.ios.kakao를 따릅니다.
    $KakaoSDKVersion=YOUR_KAKAO_SDK_VERSION 
    ```
-
+   
 #### Android
 
 1. [키 해시 등록](https://developers.kakao.com/docs/latest/ko/getting-started/sdk-android-v1#key-hash)을 진행해주세요. 자바 코드로 구하는 방법이 제일 확실합니다.
@@ -114,13 +114,7 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
      keytool -exportcert -alias androiddebugkey -keystore ~./android/app/debug.keystore -storepass android -keypass android | openssl sha1 -binary | openssl base64
      ```
 
-2. 안드로이드에서는 카카오 SDK가 모듈의 gradle 경로에 잡혀있어서 별도로 sdk를 설치하지 않아도 됩니다. 가끔 `kakao sdk`를 못찾겠다는 오류가 나오면 `build.gradle(Project)` 파일에 다음과 같이 android sdk repository를 추가해주세요.
-
-   ```
-   maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
-   ```
-
-3. Redirect URI 설정
+2. Redirect URI 설정
 
    - 카카오 로그인 기능을 구현하기 위해서는 리다이렉션(Redirection)을 통해 [Request Code](https://developers.kakao.com/docs/latest/ko/kakaologin/android)를 받아야 합니다. 그러기 위해서는 아래 코드를 `AndroidManifest.xml`에 추가해주세요. 그리고 `카카오 네이티브 앱 key를 입력해주세요` 텍스트를 본인의 카카오 네이티브 키로 변경해주시면 됩니다. (Android 12(API 31) 이상을 타깃으로 하는 앱인 경우, `exported` 요소를 반드시 "true"로 선언해야 합니다.)
 
@@ -140,7 +134,7 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
      </activity>
      ```
 
-4. `app/src/main/res/values/strings.xml` 을 열어 다음을 추가합니다
+3. `app/src/main/res/values/strings.xml` 을 열어 다음을 추가합니다
 
    ```diff
    <resources>
@@ -149,7 +143,7 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
    </resources>
    ```
 
-5. kotlin을 프로젝트에서 해석가능하도록 설치해줍니다. `android/build.gradle` 파일에 아래 변경사항을 적용해주세요.
+4. kotlin을 프로젝트에서 해석가능하도록 설치해줍니다. `android/build.gradle` 파일에 아래 변경사항을 적용해주세요.
 
    ```diff
    buildscript {
@@ -173,16 +167,40 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
    ...
    ```
 
-6. [공식문서-토큰관리](https://developers.kakao.com/docs/latest/ko/kakaologin/android#token-mgmt) 에서 참고할 수 있듯이 Android 카카오 SDK는 액세스 토큰을 자동 갱신해줍니다.
+5. [공식문서-토큰관리](https://developers.kakao.com/docs/latest/ko/kakaologin/android#token-mgmt) 에서 참고할 수 있듯이 Android 카카오 SDK는 액세스 토큰을 자동 갱신해줍니다.
 
-7. 컴파일 에러가 나면 `build.gradle`에서 android sdk compile version 등 빌드 sdk 버전을 맞춰주세요.
+6. 컴파일 에러가 나면 `build.gradle`에서 android sdk compile version 등 빌드 sdk 버전을 맞춰주세요.
 
-8. (Optional) 앱 배포 시, 코드 축소, 난독화, 최적화를 하는 경우, 카카오 SDK를 제외해야 하기 때문에 **ProGuard 규칙 파일**에 다음 코드를 추가해주세요.
+7. (Optional) 앱 배포 시, 코드 축소, 난독화, 최적화를 하는 경우, 카카오 SDK를 제외해야 하기 때문에 **ProGuard 규칙 파일**에 다음 코드를 추가해주세요.
 
    ```
    -keep class com.kakao.sdk.**.model.* { <fields>; }
    -keep class * extends com.google.gson.TypeAdapter
    ```
+
+8. 여러 라이브러리에서 동일한 버전의 SDK를 써야 하는 경우 프로젝트의 `/android/build.gradle` 파일에, 아래의 형태로 버전을 강제 지정할 수 있습니다.
+```groovy
+    project.ext {
+      set('react-native', [
+        versions: [
+          // Overriding Build/Android SDK Versions
+          android : [
+            minSdk    : 19,
+            targetSdk : 31,
+            compileSdk: 31,
+            buildTools: "30.0.3",
+            kotlin: "1.6.21"
+          ],
+          
+          // Overriding Library SDK Versions
+          kakao: [
+            // Override Kakao SDK Version
+            sdk   : "2.10.0",
+          ],
+        ],
+      ])
+    }
+```
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
    # 없는 경우에는 package.json의 sdkVersions.ios.kakao를 따릅니다.
    $KakaoSDKVersion=YOUR_KAKAO_SDK_VERSION 
    ```
-   
+
 #### Android
 
 1. [키 해시 등록](https://developers.kakao.com/docs/latest/ko/getting-started/sdk-android-v1#key-hash)을 진행해주세요. 자바 코드로 구하는 방법이 제일 확실합니다.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNKakaoLogins_kotlinVersion']
@@ -6,8 +8,6 @@ buildscript {
   repositories {
     google()
     mavenCentral()
-
-    maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
   }
 
   dependencies {
@@ -17,22 +17,33 @@ buildscript {
   }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins { id 'kotlin-android' }
+plugins { id 'com.android.library' }
+plugins { id "io.invertase.gradle.build" version "1.5" }
 
-def getExtOrDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['RNKakaoLogins_' + name]
+def getDefaultProperty(name, asInteger) {
+  def value = project.properties["RNKakaoLogins_" + name]
+  return asInteger ? value.toInteger() : value
 }
 
-def getExtOrIntegerDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['RNKakaoLogins_' + name]).toInteger()
+project.ext {
+  set("react-native", [
+      versions: [
+          android: [
+              minSdk    : getDefaultProperty("minSdkVersion", true),
+              targetSdk : getDefaultProperty("targetSdkVersion", true),
+              compileSdk: getDefaultProperty("compileSdkVersion", true),
+              kotlin: getDefaultProperty("kotlinVersion", false)
+          ],
+          kakao: [
+              sdk: getDefaultProperty("kakaoSdkVersion", false)
+          ],
+      ],
+  ])
 }
 
 android {
-  compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
   }
@@ -48,7 +59,6 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
-
   kotlinOptions {
     jvmTarget = "1.8"
   }
@@ -57,86 +67,27 @@ android {
 repositories {
   mavenCentral()
   google()
-
-  maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
-
-
-  def found = false
-  def defaultDir = null
-  def androidSourcesName = 'React Native sources'
-
-  if (rootProject.ext.has('reactNativeAndroidRoot')) {
-    defaultDir = rootProject.ext.get('reactNativeAndroidRoot')
-  } else {
-    defaultDir = new File(
-            projectDir,
-            '/../../../node_modules/react-native/android'
-    )
-  }
-
-  if (defaultDir.exists()) {
-    maven {
-      url defaultDir.toString()
-      name androidSourcesName
-    }
-
-    logger.info(":${project.name}:reactNativeAndroidRoot ${defaultDir.canonicalPath}")
-    found = true
-  } else {
-    def parentDir = rootProject.projectDir
-
-    1.upto(5, {
-      if (found) return true
-      parentDir = parentDir.parentFile
-
-      def androidSourcesDir = new File(
-              parentDir,
-              'node_modules/react-native'
-      )
-
-      def androidPrebuiltBinaryDir = new File(
-              parentDir,
-              'node_modules/react-native/android'
-      )
-
-      if (androidPrebuiltBinaryDir.exists()) {
-        maven {
-          url androidPrebuiltBinaryDir.toString()
-          name androidSourcesName
-        }
-
-        logger.info(":${project.name}:reactNativeAndroidRoot ${androidPrebuiltBinaryDir.canonicalPath}")
-        found = true
-      } else if (androidSourcesDir.exists()) {
-        maven {
-          url androidSourcesDir.toString()
-          name androidSourcesName
-        }
-
-        logger.info(":${project.name}:reactNativeAndroidRoot ${androidSourcesDir.canonicalPath}")
-        found = true
-      }
-    })
-  }
-
-  if (!found) {
-    throw new GradleException(
-            "${project.name}: unable to locate React Native android sources. " +
-                    "Ensure you have you installed React Native as a dependency in your project and try again."
-    )
-  }
 }
-
-def kotlin_version = getExtOrDefault('kotlinVersion')
-def kakao_sdk_version = getExtOrDefault('kakaoSdkVersion')
 
 dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
-  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:${ReactNative.ext.getVersion("android", "kotlin")}"
 
   // Kakao
-  implementation "com.kakao.sdk:v2-user:$kakao_sdk_version" // 카카오 로그인
-  implementation "com.kakao.sdk:v2-talk:$kakao_sdk_version" // 친구, 메시지(카카오톡)
-  implementation "com.kakao.sdk:v2-story:$kakao_sdk_version" // 카카오 스토리
+  implementation "com.kakao.sdk:v2-user:${ReactNative.ext.getVersion("kakao", "sdk")}" // 카카오 로그인
+  implementation "com.kakao.sdk:v2-talk:${ReactNative.ext.getVersion("kakao", "sdk")}" // 친구, 메시지(카카오톡)
+  implementation "com.kakao.sdk:v2-story:${ReactNative.ext.getVersion("kakao", "sdk")}" // 카카오 스토리
+}
+
+ReactNative.shared.applyPackageVersion()
+ReactNative.shared.applyDefaultExcludes()
+ReactNative.module.applyAndroidVersions()
+ReactNative.module.applyReactNativeDependency("api")
+rootProject.allprojects {
+  repositories {
+    maven {
+      url 'https://devrepo.kakao.com/nexus/content/groups/public/'
+    }
+  }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,6 @@
-RNKakaoLogins_kotlinVersion=1.3.50
+RNKakaoLogins_minSdkVersion=21
 RNKakaoLogins_compileSdkVersion=31
 RNKakaoLogins_targetSdkVersion=31
-RNKakaoLogins_kakaoSdkVersion=2.9.0
 RNKakaoLogins_gradleVersion=4.1.0
+RNKakaoLogins_kotlinVersion=1.3.50
+RNKakaoLogins_kakaoSdkVersion=2.9.0


### PR DESCRIPTION
## Description
- react-native-fireabse 를 관리하고 있는 invertase 의 [gradle plugin](https://github.com/invertase/react-native-gradle-plugin) 을 적용했습니다.
build.gradle 의 redundant 한 코드 제거와 의존하는 sdk 버전의 관리가 한결 더 간편해집니다.
(kakao-sdk 가 버전을 하나로 관리하는 것 같아서, 패키지별로 버전을 지정하게끔 하지는 않았습니다.)
- root project 에 kakao maven repository 를 주입하는 스크립트를 추가했습니다.
이제 더이상 사용자가 프로젝트 build.gradle 의 allprojects 에 따로 maven repository 를 넣지 않아도 됩니다.



## Test plan
- [x] 샘플앱의 allprojects.repositories 의 카카오 maven url 을 제거한 상태로 빌드가 정상적으로 이루어집니다.
- [x] 샘플앱의 kakao sdk 버전이 정상적으로 override 되는지 확인합니다.