### PR TITLE
fix(android): order of gradle plugins

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,9 +17,11 @@ buildscript {
   }
 }
 
-plugins { id 'kotlin-android' }
-plugins { id 'com.android.library' }
-plugins { id "io.invertase.gradle.build" version "1.5" }
+plugins {
+  id "com.android.library"
+  id "kotlin-android"
+  id "io.invertase.gradle.build" version "1.5"
+}
 
 def getDefaultProperty(name, asInteger) {
   def value = project.properties["RNKakaoLogins_" + name]


### PR DESCRIPTION
resolve #312

순서를 변경하거나, kotlin-gradle-plugin 버전을 1.6.0 이상으로 올리면 문제가 해결됩니다.
반영은 안했는데, README.md 에서 안내하는 버전(1.3.41)과 SDK `gradle.properties` 의 기본 버전도
1.6.0 이상으로 업데이트하는게 어떨까 제안드립니다!
