### PR TITLE
카카오 SDK 버전 및 의존성 변경 (Xcode 14 빌드 지원)

### DIFF
--- a/kakao-login.podspec
+++ b/kakao-login.podspec
@@ -3,7 +3,7 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-kakao_sdk_version = "2.9.0"
+kakao_sdk_version = "2.11.1"
 
 Pod::Spec.new do |s|
   s.name         = "kakao-login"

--- a/kakao-login.podspec
+++ b/kakao-login.podspec
@@ -35,6 +35,5 @@ Pod::Spec.new do |s|
   s.dependency 'KakaoSDKCommon',  kakao_sdk_version
   s.dependency 'KakaoSDKAuth',  kakao_sdk_version
   s.dependency 'KakaoSDKUser', kakao_sdk_version
-  s.dependency 'KakaoSDKTalk', kakao_sdk_version
 end
 

--- a/kakao-login.podspec
+++ b/kakao-login.podspec
@@ -32,7 +32,6 @@ Pod::Spec.new do |s|
     kakao_sdk_version = $KakaoSDKVersion
   end
 
-  s.dependency 'KakaoSDK', kakao_sdk_version
   s.dependency 'KakaoSDKCommon',  kakao_sdk_version
   s.dependency 'KakaoSDKAuth',  kakao_sdk_version
   s.dependency 'KakaoSDKUser', kakao_sdk_version


### PR DESCRIPTION
안녕하세요.
RN 커뮤니티를 향한 많은 기여에 감사한 마음으로 라이브러리를 이용하고 있습니다.

Xcode 14 환경에서 빌드 실패 현상 관련하여 (#326)
1. [카카오 SDK의 대응 버전](https://developers.kakao.com/docs/latest/ko/sdk-download/ios#changelog)으로 기본값을 수정
2. 모든 카카오 SDK를 설치하도록 설정된 의존성 설정을 수정

위 두가지 변경점을 포함한 Pull Request 드려봅니다.

---
**의존성 변경에 대해**

KakaoSDKFriend 모듈의 Alamofire 관련 문제를 해결하기 위한 목적으로 변경했지만
카카오 개발 문서를 살펴보니 카카오 로그인 기능을 구현하는데 필요한 개별 모듈은 아래 3개이며
모든 모듈을 설치할 필요는 없다고 생각되어 변경을 요청드리게 되었습니다.

[카카오 로그인 - 모듈 설정](https://developers.kakao.com/docs/latest/ko/kakaologin/ios#before-you-begin-module)
<img width="815" alt="image" src="https://user-images.githubusercontent.com/22050211/190191202-d55d7e17-f87b-45db-91e3-8a835a2e6dda.png">


[모듈간 의존성](https://developers.kakao.com/docs/latest/ko/getting-started/sdk-ios#select-module-dependency)
<img width="807" alt="image" src="https://user-images.githubusercontent.com/22050211/190192539-0561280d-529e-475c-b753-f4ec4c6ddee5.png">

---
**테스트**

KakaoLoginExample 앱을 Xcode 14에서 iPhone 14 Pro 시뮬레이터에 빌드하는 데에는 문제가 없었습니다. (M1 Pro)

동작까지 테스트 해보고 싶었지만 예제앱의 JS 번들링에 문제가 있었고, 이걸 해결하는데 시간이 좀 걸릴 것 같아 우선 PR을 올려 검토를 요청드리게 되었습니다.

(예제앱에서 `@react-native-seoul/kakao-login` 모듈 resolve 하지 못함)