### PR TITLE
fix: expo plugin 에러

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "postinstall": "dooboolab-welcome postinstall",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc && flowgen src/index.d.ts -o src/index.js.flow",
+    "build": "tsc && tsc -P ./plugins && flowgen src/index.d.ts -o src/index.js.flow",
     "flow": "flow",
     "lint": "eslint -c .eslintrc.js 'src'",
     "validate": "npm run lint && npm run test:typescript && npm run test:flow && npm run test"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
   },
   "compileOnSave": true,
   "exclude": ["node_modules"],
-  "include": ["src", "plugins"]
+  "include": ["src"]
 }


### PR DESCRIPTION
패키지 빌드 시에 plugins 폴더의 ts파일을 컴파일해주어야 하는데
이게 빠져 있었네요.