### PR TITLE
Fix android kakaoSdkVersion from 2.11.1 to 2.11.2

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ RNKakaoLogins_compileSdkVersion=31
 RNKakaoLogins_targetSdkVersion=31
 RNKakaoLogins_gradleVersion=4.1.0
 RNKakaoLogins_kotlinVersion=1.3.50
-RNKakaoLogins_kakaoSdkVersion=2.11.1
+RNKakaoLogins_kakaoSdkVersion=2.11.2


### PR DESCRIPTION
 - 안드로이드 카카오톡 미설치 기기에서 카카오 로그인 정상적으로 처리 안되는 이슈 해결하기 위한 PR입니다.
 - 다운받은 라이브러리가 사용중인 카카오 SDK 버전이 2.11.1인데, 해당 버전에서 로그인 관련 버그가 있어서 카카오 sdk 버전이 2.11.2로 업그레이드 되었으나, 라이브리는 2.11.1을 사용하고 있었습니다.
 - 이에 따라 버전 안드로이드 카카오톡 sdk 버전을 2.11.2로 수정해줌.

https://github.com/react-native-seoul/react-native-kakao-login/issues/340