### PR TITLE
Android에 Custom Scheme 등록할 수 있게 설정

### DIFF
--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
@@ -223,6 +223,14 @@ class RNKakaoLoginsModule(private val reactContext: ReactApplicationContext) : R
     init {
         val kakaoAppKey = reactContext.resources.getString(
                 reactContext.resources.getIdentifier("kakao_app_key", "string", reactContext.packageName))
-        init(reactContext, kakaoAppKey)
+        val kakaoCustomSchemeId = reactContext.resources.getIdentifier(
+            "kakao_custom_scheme", "string", context.packageName
+        )
+        val kakaoCustomScheme = if (kakaoCustomSchemeId == 0) null else context.getString(kakaoCustomSchemeId)
+        init(
+            context = reactContext, 
+            appKey = kakaoAppKey,
+            customScheme = kakaoCustomScheme
+        )
     }
 }


### PR DESCRIPTION
## 기능 추가

- 안드로이드에서 동일한 URL Scheme을 여러 앱에서 사용하는 경우 카카오 로그인에 성공했을 때 본인이 작업하고 있지 않은 다른 앱이 설치 되어 있으면 그 앱으로도 리다이렉트가 될 수 있게 Intent Chooser가 떠오를 수 있습니다.
- 이런 경우 각 앱/빌드 형상에 맞게 Custom Scheme을 넣어줘야 카카오 로그인에 성공했을 때 본인이 현재 작업하고 있는 앱으로만 리다이렉트 할 수 있습니다. 이를 SDK 차원에서 지원하기 위해 KakaoSdk를 초기화할 때 customScheme 패러미터를 따로받고 있습니다.
- 라이브러리에서 이 기능을 사용할 수 있게 res/string에 KAKAO_CUSTOM_SCHEME의 value를 가져와서(해당 key의 value가 없으면 null) SDK 초기화 시 사용할 수 있도록 코드 수정을 했습니다.

<img width="551" alt="스크린샷 2022-11-21 오후 5 20 24" src="https://user-images.githubusercontent.com/54518925/202999576-8fc69850-4580-4268-89e6-3e86ca653974.png">

SDK에서도 customScheme이 없는 경우 null을 넣어서 초기화 로직을 처리하고 있으니 이 부분에 관련된 문제는 없을 것 같습니다.