### PR TITLE
expo 53을 위한 코틀린 버전 명시 코드 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ npx expo install expo-build-properties
         "@react-native-seoul/kakao-login",
         {
           "kakaoAppKey": "{{kakao api key}}",
-          "overrideKakaoSDKVersion": "2.11.2", // Optional, 
-          "kotlinVersion": "1.9.0" // #392
+          "overrideKakaoSDKVersion": "2.11.2", // Optional,
         }
       ],
       [

--- a/plugins/android/withAndroidKakaoLogin.ts
+++ b/plugins/android/withAndroidKakaoLogin.ts
@@ -2,12 +2,11 @@ import {
   AndroidConfig,
   ConfigPlugin,
   withAndroidManifest,
-  withStringsXml,
-  withGradleProperties,
   withProjectBuildGradle,
+  withStringsXml
 } from '@expo/config-plugins';
-import {ManifestActivity} from '@expo/config-plugins/build/android/Manifest';
-import {KakaoLoginPluginProps} from '..';
+import { ManifestActivity } from '@expo/config-plugins/build/android/Manifest';
+import { KakaoLoginPluginProps } from '..';
 
 const ACTIVITY_NAME = 'com.kakao.sdk.auth.AuthCodeHandlerActivity';
 
@@ -89,38 +88,6 @@ const modifyProjectBuildGradle: ConfigPlugin<KakaoLoginPluginProps> = (
   config,
   props,
 ) => {
-  config = withGradleProperties(config, (config) => {
-    AndroidConfig.BuildProperties.updateAndroidBuildProperty(
-      config.modResults,
-      'android.kotlinVersion',
-      props.kotlinVersion ?? '1.5.10',
-    );
-
-    return config;
-  });
-
-  config = withProjectBuildGradle(config, (config) => {
-    if (
-      !config.modResults.contents.includes(
-        'org.jetbrains.kotlin:kotlin-gradle-plugin:',
-      )
-    ) {
-      // config.modResults.contents = config.modResults.contents.replace(
-      //   `buildToolsVersion = "29.0.3"`,
-      //   `buildToolsVersion = "30.0.0"`
-      // );
-      config.modResults.contents = config.modResults.contents.replace(
-        /dependencies\s?{/,
-        `dependencies {
-          classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:${
-            props.kotlinVersion ?? '1.5.10'
-          }'`,
-      );
-    }
-
-    return config;
-  });
-
   if (props.overrideKakaoSDKVersion) {
     config = withProjectBuildGradle(config, (config) => {
       const regex = /project.ext {.*\n.*set\('react-native', \[\n.*\]\)\n.*\}/s;

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,11 +1,10 @@
-import {withAndroidKakaoLogin} from './android/withAndroidKakaoLogin';
-import {withIosKakaoLogin} from './ios/withIosKakaoLogin';
-import {ConfigPlugin, createRunOncePlugin} from '@expo/config-plugins';
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+import { withAndroidKakaoLogin } from './android/withAndroidKakaoLogin';
+import { withIosKakaoLogin } from './ios/withIosKakaoLogin';
 
 export interface KakaoLoginPluginProps {
   kakaoAppKey: string;
   overrideKakaoSDKVersion?: string;
-  kotlinVersion?: string;
 }
 
 const withExpoConfigPlugins: ConfigPlugin<KakaoLoginPluginProps> = (


### PR DESCRIPTION
https://github.com/crossplatformkorea/react-native-kakao-login/issues/423

위 이슈랑 결합된 이슈인데, kakao-login에서 코틀린 버전을 명시하여 사용하고 있던 내용을 제거했습니다.

- 기존에 왜 1.5.10으로 강제되어있었는지 몰라서, 레거시 검토가 필요합니다.
- expo 53 이전 버전에서 동작이 잘 되는지 테스트도 필요합니다.