### PR TITLE
feat: add nonce support for OpenID Connect in login

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,6 +53,7 @@ dependencies {
   // Kakao
   def kakaoVersion = getExtOrDefault('kakaoSdkVersion')
   implementation "com.kakao.sdk:v2-user:$kakaoVersion" // 카카오 로그인
+  implementation "com.kakao.sdk:v2-auth:$kakaoVersion" // 카카오 인증 (OAuthTokenRequest 포함)
   implementation "com.kakao.sdk:v2-talk:$kakaoVersion" // 친구, 메시지(카카오톡)
   implementation "com.kakao.sdk:v2-story:2.17.0" // 카카오 스토리(지원 중단으로 버전 고정)
 }

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
@@ -21,13 +21,13 @@ class RNKakaoLoginsModule(private val reactContext: ReactApplicationContext) : R
     }
 
     @ReactMethod
-    private fun login(promise: Promise) {
+    private fun login(nonce: String?, promise: Promise) {
         if (UserApiClient.instance.isKakaoTalkLoginAvailable(reactContext)) {
             reactContext.currentActivity?.let {
                 UserApiClient.instance.loginWithKakaoTalk(it) { token, error: Throwable? ->
                     if (error != null) {
                         if (error is AuthError && error.statusCode == 302) {
-                            this.loginWithKakaoAccount(promise)
+                            this.loginWithKakaoAccount(null, promise)
                             return@loginWithKakaoTalk
                         }
                         promise.reject("RNKakaoLogins", error.message, error)
@@ -57,38 +57,83 @@ class RNKakaoLoginsModule(private val reactContext: ReactApplicationContext) : R
                 }
             }
         } else {
-            UserApiClient.instance.loginWithKakaoAccount(reactContext) { token, error: Throwable? ->
-                if (error != null) {
-                    promise.reject("RNKakaoLogins", error.message, error)
-                    return@loginWithKakaoAccount
-                }
-
-                if (token != null) {
-                    val (accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, idToken, scopes) = token
-                    val map = Arguments.createMap()
-                    map.putString("accessToken", accessToken)
-                    map.putString("refreshToken", refreshToken)
-                    map.putString("idToken", idToken)
-                    map.putString("accessTokenExpiresAt", dateFormat(accessTokenExpiresAt))
-                    map.putString("refreshTokenExpiresAt", dateFormat(refreshTokenExpiresAt))
-                    val scopeArray = Arguments.createArray()
-                    if (scopes != null) {
-                        for (scope in scopes) {
-                            scopeArray.pushString(scope)
-                        }
+            // If nonce is provided, use loginWithKakaoAccount (supports OpenID Connect)
+            if (!nonce.isNullOrEmpty()) {
+                this.loginWithKakaoAccount(nonce, promise)
+            } else {
+                UserApiClient.instance.loginWithKakaoAccount(reactContext) { token, error: Throwable? ->
+                    if (error != null) {
+                        promise.reject("RNKakaoLogins", error.message, error)
+                        return@loginWithKakaoAccount
                     }
-                    map.putArray("scopes", scopeArray)
-                    promise.resolve(map)
-                    return@loginWithKakaoAccount
-                }
 
-                promise.reject("RNKakaoLogins", "Token is null")
+                    if (token != null) {
+                        val (accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, idToken, scopes) = token
+                        val map = Arguments.createMap()
+                        map.putString("accessToken", accessToken)
+                        map.putString("refreshToken", refreshToken)
+                        map.putString("idToken", idToken)
+                        map.putString("accessTokenExpiresAt", dateFormat(accessTokenExpiresAt))
+                        map.putString("refreshTokenExpiresAt", dateFormat(refreshTokenExpiresAt))
+                        val scopeArray = Arguments.createArray()
+                        if (scopes != null) {
+                            for (scope in scopes) {
+                                scopeArray.pushString(scope)
+                            }
+                        }
+                        map.putArray("scopes", scopeArray)
+                        promise.resolve(map)
+                        return@loginWithKakaoAccount
+                    }
+
+                    promise.reject("RNKakaoLogins", "Token is null")
+                }
             }
         }
     }
 
     @ReactMethod
-    private fun loginWithKakaoAccount(promise: Promise) {
+    private fun loginWithKakaoAccount(nonce: String?, promise: Promise) {
+        // Use loginWithKakaoAccount for OpenID Connect support (nonce)
+        if (!nonce.isNullOrEmpty()) {
+            UserApiClient.instance.loginWithKakaoAccount(
+                reactContext,
+                null, // prompts: List<Prompt>?
+                null, // loginHint: String?
+                nonce, // nonce: String?
+                null, // channelPublicIds: List<String>?
+                null  // serviceTerms: List<String>?
+            ) { token, error: Throwable? ->
+                if (error != null) {
+                    promise.reject("RNKakaoLogins", error.message, error)
+                    return@loginWithKakaoAccount
+                }
+
+                if (token == null) {
+                    promise.reject("RNKakaoLogins", "Token is null")
+                    return@loginWithKakaoAccount
+                }
+
+                val (accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, idToken, tokenScopes) = token
+                val map = Arguments.createMap()
+                map.putString("accessToken", accessToken)
+                map.putString("refreshToken", refreshToken)
+                map.putString("idToken", idToken)
+                map.putString("accessTokenExpiresAt", dateFormat(accessTokenExpiresAt))
+                map.putString("refreshTokenExpiresAt", dateFormat(refreshTokenExpiresAt))
+                val scopeArray = Arguments.createArray()
+                if (tokenScopes != null) {
+                    for (scope in tokenScopes) {
+                        scopeArray.pushString(scope)
+                    }
+                }
+                map.putArray("scopes", scopeArray)
+                promise.resolve(map)
+                return@loginWithKakaoAccount
+            }
+            return
+        }
+        
         UserApiClient.instance.loginWithKakaoAccount(reactContext) { token, error: Throwable? ->
             if (error != null) {
                 promise.reject("RNKakaoLogins", error.message, error)

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -4,8 +4,8 @@
 
 @interface RCT_EXTERN_MODULE(RNKakaoLogins, NSObject)
 
-RCT_EXTERN_METHOD(login:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
-RCT_EXTERN_METHOD(loginWithKakaoAccount:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
+RCT_EXTERN_METHOD(login:(NSString * _Nullable)nonce resolver:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
+RCT_EXTERN_METHOD(loginWithKakaoAccount:(NSString * _Nullable)nonce resolver:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 RCT_EXTERN_METHOD(logout:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 RCT_EXTERN_METHOD(unlink:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 RCT_EXTERN_METHOD(getProfile:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);

--- a/ios/RNKakaoLogins/RNKakaoLogins.swift
+++ b/ios/RNKakaoLogins/RNKakaoLogins.swift
@@ -46,14 +46,17 @@ class RNKakaoLogins: NSObject {
         return AuthController.handleOpenUrl(url: url)
     }
 
-    @objc(login:rejecter:)
-    func login(_ resolve: @escaping RCTPromiseResolveBlock,
+    @objc(login:resolver:rejecter:)
+    func login(_ nonce: String?,
+                resolver resolve: @escaping RCTPromiseResolveBlock,
                 rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         DispatchQueue.main.async {
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss";
-
-            if (UserApi.isKakaoTalkLoginAvailable()) {
+            
+            // If nonce is provided, use loginWithKakaoAccount (supports OpenID Connect)
+            // Otherwise, try KakaoTalk login first, then fallback to KakaoAccount
+            if (UserApi.isKakaoTalkLoginAvailable() && (nonce == nil || nonce!.isEmpty)) {
                 UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
                     if let error = error {
                         reject("RNKakaoLogins", error.localizedDescription, nil)
@@ -70,7 +73,8 @@ class RNKakaoLogins: NSObject {
                     }
                 }
             } else {
-                UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
+                // Use loginWithKakaoAccount for OpenID Connect support (nonce)
+                UserApi.shared.loginWithKakaoAccount(prompts: nil, loginHint: nil, nonce: nonce) {(oauthToken, error) in
                     if let error = error {
                         reject("RNKakaoLogins", error.localizedDescription, nil)
                     }
@@ -89,13 +93,16 @@ class RNKakaoLogins: NSObject {
         }
     }
 
-    @objc(loginWithKakaoAccount:rejecter:)
-    func loginWithKakaoAccount(_ resolve: @escaping RCTPromiseResolveBlock,
-                rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+    @objc(loginWithKakaoAccount:resolver:rejecter:)
+    func loginWithKakaoAccount(_ nonce: String?,
+                                resolver resolve: @escaping RCTPromiseResolveBlock,
+                                rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         DispatchQueue.main.async {
-                    let dateFormatter = DateFormatter()
-                    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss";
-            UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+            
+            // Use loginWithKakaoAccount for OpenID Connect support (nonce)
+            UserApi.shared.loginWithKakaoAccount(prompts: nil, loginHint: nil, nonce: nonce) {(oauthToken, error) in
                 if let error = error {
                     reject("RNKakaoLogins", error.localizedDescription, nil)
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import {NativeModules} from 'react-native';
-import {KakaoLoginModuleInterface, KakaoLoginOptions, KaKaoLoginWebType} from './types';
+import {
+  KakaoLoginModuleInterface,
+  KakaoLoginOptions,
+  KaKaoLoginWebType,
+} from './types';
 
 const {RNKakaoLogins} = NativeModules;
 
@@ -8,16 +12,16 @@ const NativeKakaoLogins: KakaoLoginModuleInterface = {
     if (!props) {
       return RNKakaoLogins.login(null);
     }
-    
+
     const kakaoLoginOptions = props as KakaoLoginOptions;
-    
+
     return RNKakaoLogins.login(kakaoLoginOptions.nonce || null);
   },
   loginWithKakaoAccount(props?: KakaoLoginOptions) {
     if (!props) {
       return RNKakaoLogins.loginWithKakaoAccount(null);
     }
-    
+
     return RNKakaoLogins.loginWithKakaoAccount(props.nonce || null);
   },
   logout() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,24 @@
 import {NativeModules} from 'react-native';
-import {KakaoLoginModuleInterface} from './types';
+import {KakaoLoginModuleInterface, KakaoLoginOptions, KaKaoLoginWebType} from './types';
 
 const {RNKakaoLogins} = NativeModules;
 
 const NativeKakaoLogins: KakaoLoginModuleInterface = {
-  login() {
-    return RNKakaoLogins.login();
+  login(props?: KakaoLoginOptions | KaKaoLoginWebType) {
+    if (!props) {
+      return RNKakaoLogins.login(null);
+    }
+    
+    const kakaoLoginOptions = props as KakaoLoginOptions;
+    
+    return RNKakaoLogins.login(kakaoLoginOptions.nonce || null);
   },
-  loginWithKakaoAccount() {
-    return RNKakaoLogins.loginWithKakaoAccount();
+  loginWithKakaoAccount(props?: KakaoLoginOptions) {
+    if (!props) {
+      return RNKakaoLogins.loginWithKakaoAccount(null);
+    }
+    
+    return RNKakaoLogins.loginWithKakaoAccount(props.nonce || null);
   },
   logout() {
     return RNKakaoLogins.logout();

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -1,12 +1,16 @@
-import {KaKaoLoginWebType, KakaoLoginModuleInterface} from './types';
+import {
+  KaKaoLoginWebType,
+  KakaoLoginModuleInterface,
+  KakaoLoginOptions,
+} from './types';
 
 const WebKakaoLogins: KakaoLoginModuleInterface = {
-  login(props?: KaKaoLoginWebType) {
+  login(props?: KaKaoLoginWebType | KakaoLoginOptions) {
     if (!props) {
       throw new Error('Web parameters are not provided');
     }
 
-    const {restApiKeyWeb, redirectUrlWeb, codeWeb} = props;
+    const {restApiKeyWeb, redirectUrlWeb, codeWeb} = props as KaKaoLoginWebType;
 
     if (!restApiKeyWeb || !redirectUrlWeb || !codeWeb) {
       throw new Error('Web parameters are not provided');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,9 +22,9 @@ export interface KakaoLoginModuleInterface {
   serviceTerms(): Promise<KakaoUserServiceTerms>;
 }
 
-export type KakaoLoginOptions ={
+export type KakaoLoginOptions = {
   nonce?: string;
-}
+};
 
 export type KakaoOAuthToken = {
   accessToken: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export interface KakaoLoginModuleInterface {
   login(): Promise<KakaoOAuthToken>;
+  login(props: KakaoLoginOptions): Promise<KakaoOAuthToken>;
   login(props: KaKaoLoginWebType): Promise<KakaoOAuthWebToken>;
 
   logout(): Promise<string>;
@@ -14,10 +15,15 @@ export interface KakaoLoginModuleInterface {
   getAccessToken(): Promise<KakaoAccessTokenInfo>;
 
   loginWithKakaoAccount(): Promise<KakaoOAuthToken>;
+  loginWithKakaoAccount(props: KakaoLoginOptions): Promise<KakaoOAuthToken>;
 
   shippingAddresses(): Promise<KakaoShippingAddresses>;
 
   serviceTerms(): Promise<KakaoUserServiceTerms>;
+}
+
+export type KakaoLoginOptions ={
+  nonce?: string;
 }
 
 export type KakaoOAuthToken = {


### PR DESCRIPTION
#428 이슈

ios 시뮬레이터, 안드로이드 실제 기기와 연동하여 테스트 완료했습니다 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional nonce support for login and account-login flows across iOS, Android, and Web, enabling OpenID Connect flows and returning idToken when available.
* **Types / API**
  * JS/TypeScript API updated: login and loginWithKakaoAccount accept an optional KakaoLoginOptions (nonce). Web entry now accepts the same options. Public promise-based APIs updated to surface the new parameter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->