### PR TITLE
fix(android): ship ProGuard consumer rules for R8 full mode

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,12 @@ gen/
 node_modules/
 KakaoLoginExample/
 image/
+android/.gradle/
+android/build/
 
+# Ship the generated declarations, not the TypeScript sources.
+# The negation must NOT start with `**/` — npm-packlist stops honouring every
+# preceding directory rule once it sees one, which is how KakaoLoginExample/
+# and image/ ended up inside the published 6.0.3 tarball.
 **/*.ts
-!**/*.d.ts
+!*.d.ts

--- a/README.md
+++ b/README.md
@@ -173,19 +173,16 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
 
 5. 컴파일 에러가 나면 `build.gradle`에서 android sdk compile version 등 빌드 sdk 버전을 맞춰주세요.
 
-6. (Optional) 앱 배포 시, 코드 축소, 난독화, 최적화를 하는 경우, 카카오 SDK를 제외해야 하기 때문에 **ProGuard 규칙 파일**에 다음 코드를 추가해주세요.
+6. (Optional) 앱 배포 시, 코드 축소, 난독화, 최적화(`minifyEnabled true`)를 하는 경우 참고해주세요.
 
-[공식 문서](https://developers.kakao.com/docs/latest/ko/android/getting-started#project-pro-guard)
+   **별도 설정이 필요하지 않습니다.** 이 라이브러리는 [android/consumer-rules.pro](./android/consumer-rules.pro)를 통해 카카오 SDK와 SDK가 내부적으로 사용하는 Retrofit / OkHttp 의 ProGuard 규칙을 자동으로 포함하며, AGP가 이를 앱 빌드에 자동으로 병합합니다. R8 full mode(AGP 8 부터 기본값)에서도 그대로 동작합니다.
 
-```
--keep class com.kakao.sdk.**.model.* { <fields>; }
--keep class * extends com.google.gson.TypeAdapter
+   > 반대로 [공식 문서](https://developers.kakao.com/docs/latest/ko/android/getting-started#project-pro-guard)의 규칙만 직접 추가한 경우에는 release 빌드가 실패하거나 로그인 시 크래시가 발생할 수 있습니다 ([#438](https://github.com/crossplatformkorea/react-native-kakao-login/issues/438)).
+   >
+   > - 카카오 SDK가 사용하는 Retrofit 2.9.0 은 자체 ProGuard 규칙을 배포하지만, Retrofit 2.10/2.11 에서 추가된 R8 full mode 대응 규칙(서비스 인터페이스의 제네릭 반환 타입 보존 등)이 빠져 있습니다.
+   > - 카카오 SDK가 사용하는 OkHttp 4.9.3 에는 bouncycastle / conscrypt / openjsse `-dontwarn` 규칙이 없어, 이 규칙이 없으면 R8 이 `Missing classes` 오류로 빌드 자체를 실패시킵니다.
 
-# https://github.com/square/okhttp/pull/6792
--dontwarn org.bouncycastle.jsse.**
--dontwarn org.conscrypt.*
--dontwarn org.openjsse.**
-```
+   규칙을 직접 관리해야 하는 경우(autolinking 미사용 등)에는 [android/consumer-rules.pro](./android/consumer-rules.pro) 의 내용을 그대로 `proguard-rules.pro` 에 복사해주세요. 각 규칙이 필요한 이유는 해당 파일에 주석으로 정리되어 있습니다.
 
 7. Gradle 및 카카오 SDK의 버전을 변경해야 하는 경우, [android/gradle.properties](./android/gradle.properties) 에 있는 항목들을 확인하고, Android gradle의 root project의 ext에 `RNKakaoLogins_` 를 제외한 버전을 명시해주세요.
 
@@ -226,8 +223,7 @@ npx expo install expo-build-properties
 }
 ```
 
-3. (Optional) Android에서 난독화를 사용하실 경우, [Expo BuildProperties](https://docs.expo.dev/versions/latest/sdk/build-properties/) 를 이용해
-   Proguard Rule을 [공식 문서](https://developers.kakao.com/docs/latest/ko/android/getting-started#project-pro-guard)와 같이 설정해줍니다.
+3. (Optional) Android에서 난독화(`minifyEnabled: true`)를 사용하실 경우에도 **별도 설정이 필요하지 않습니다.** autolinking 으로 연결된 이 라이브러리의 [consumer-rules.pro](./android/consumer-rules.pro) 가 카카오 SDK / Retrofit / OkHttp 관련 ProGuard 규칙을 자동으로 포함하므로, `prebuild` 이후 생성되는 `android/app/proguard-rules.pro` 에 별도로 규칙을 주입할 필요가 없습니다. 그 밖의 커스터마이징이 필요한 경우에만 [Expo BuildProperties](https://docs.expo.dev/versions/latest/sdk/build-properties/) 를 사용해주세요.
 
 ## Methods
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,7 @@ android {
     targetSdkVersion getExtOrDefault('targetSdkVersion').toInteger()
     versionCode 1
     versionName "1.0"
+    consumerProguardFiles 'consumer-rules.pro'
   }
   buildTypes {
     release {

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,64 @@
+# Consumer ProGuard rules for @react-native-seoul/kakao-login.
+#
+# AGP applies these automatically to any app that depends on this library once
+# code shrinking/obfuscation (minifyEnabled true) is enabled, so consumers no
+# longer need to copy them into their own proguard-rules.pro. See issue #438.
+
+# Kakao serializes with kotlinx.serialization (v2-common pulls
+# kotlinx-serialization-json, v2-network the retrofit converter). The generated
+# $$serializer classes bake the JSON names in as string constants, so model
+# classes themselves may be obfuscated — but their fields may not:
+# com.kakao.sdk.common.json.GenericEnumSerializer resolves @SerialName through
+# enumClass.getDeclaredField(<constant name>), and finds the @UnknownValue
+# marker the same way. kotlinx-serialization-core ships its own
+# META-INF/proguard rules, so no further serialization keeps are needed here.
+-keep class com.kakao.sdk.**.model.* { <fields>; }
+-keep interface com.kakao.sdk.** { *; }
+-keepattributes Signature,InnerClasses,EnclosingMethod
+-keepattributes RuntimeVisibleAnnotations,RuntimeInvisibleAnnotations,RuntimeVisibleParameterAnnotations,RuntimeInvisibleParameterAnnotations,AnnotationDefault
+
+# GenericEnumSerializer builds its name map from Class.getEnumConstants(), which
+# ART implements by reflectively invoking the enum's static values(). R8 strips
+# values() unless something keeps it, and getEnumConstants() then returns null —
+# an NPE inside the serializer on me() / shippingAddresses() / serviceTerms() or
+# on any API error. AGP's bundled proguard-android.txt does keep enums globally,
+# but borrowing that from the consumer's proguardFiles list would leave these
+# rules incomplete on their own.
+-keepclassmembers enum com.kakao.sdk.** {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+    <fields>;
+}
+
+# Legacy: Kakao SDK 2.20.x and earlier serialized with Gson (v2-common 2.20.1
+# depends on gson 2.8.9, which ships no rules of its own). This is a no-op on
+# the pinned 2.24.x and is kept only for consumers who pin an older
+# RNKakaoLogins_kakaoSdkVersion. Scoped to the Kakao packages on purpose — the
+# unscoped `-keep class * extends com.google.gson.TypeAdapter` from Kakao's docs
+# would pin every TypeAdapter in the *consuming* app as well.
+-keep class com.kakao.sdk.** extends com.google.gson.TypeAdapter
+
+# Optional TLS providers referenced by OkHttp. Kakao pins okhttp 4.9.3, whose
+# bundled okhttp3.pro predates https://github.com/square/okhttp/pull/6792, so
+# without these R8 fails the release build outright with "Missing classes".
+-dontwarn org.bouncycastle.jsse.**
+-dontwarn org.conscrypt.*
+-dontwarn org.openjsse.**
+
+# The Kakao SDK pins Retrofit 2.9.0 (com.kakao.sdk:v2-network). Retrofit 2.9.0
+# does ship META-INF/proguard/retrofit2.pro and AGP does apply it, but that file
+# predates the R8 full-mode hardening added in Retrofit 2.10/2.11. The block
+# below backports exactly that delta — most importantly the rules preserving the
+# generic return types (Call<AccessTokenResponse>, Call<UserResponse>) of the
+# annotated com.kakao.sdk.auth.AuthApi / com.kakao.sdk.user.UserApi service
+# interfaces, which R8 full mode (the AGP default since 8.0) otherwise erases.
+# Verbatim from Retrofit 2.11.0:
+# https://github.com/square/retrofit/blob/2.11.0/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface * extends <1>
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+-keep,allowobfuscation,allowshrinking class retrofit2.Response


### PR DESCRIPTION
Fixes #438.

Apps building a minified Android release had to copy Kakao's documented ProGuard rules by hand, and those rules are not sufficient: under R8 full mode (the AGP default since 8.0) the release build either fails outright or crashes at login. This ships the rules from the library via `consumerProguardFiles`, so consumers need no configuration at all.

## Verification

Built against a real R8 full-mode release (AGP 8.12, Gradle 8.14.3, Kakao SDK 2.24.0, `android.enableR8.fullMode=true`), with the consuming app's own `proguard-rules.pro` left **empty** so every rule had to arrive through the library:

| consumer rules | result |
| --- | --- |
| none | `:app:minifyReleaseWithR8` **fails** — `Missing classes` for bouncycastle / conscrypt / openjsse |
| Kakao's documented set | builds, but R8 strips `kotlin.coroutines.Continuation`, `retrofit2.Response` and 8 `com.kakao.sdk` interfaces |
| this PR | builds clean; all of the above retained (31 additional seeds, **nothing** newly dropped) |

Also confirmed the rules reach consumers on both delivery paths: as a Gradle subproject (RN/Expo autolinking) and inside the packaged AAR (`proguard.txt`, 3.8 kB).

## Three corrections to the issue's diagnosis

Each checked against the artifacts rather than the docs.

**Retrofit 2.9.0 does ship `META-INF/proguard/retrofit2.pro`**, and AGP applies it. It is missing exactly the five rules added in 2.10/2.11 — chiefly the ones preserving the generic return types of annotated service interfaces (`Call<AccessTokenResponse>`, `Call<UserResponse>`). Only that delta is backported, and the comment says so instead of the refutable "2.9 ships no full-mode rules".

**Kakao 2.24.0 serializes with kotlinx.serialization, not Gson** — no Gson anywhere in `v2-common` / `v2-network` / `v2-auth` / `v2-user`. The documented `-keep class * extends com.google.gson.TypeAdapter` is a leftover from 2.20.x (which did depend on gson 2.8.9). Since consumer rules merge into the whole app program, that rule would pin every `TypeAdapter` in the **consuming** app, so it is scoped to `com.kakao.sdk.**` and kept only for consumers pinning an older SDK.

**An enum keep was missing.** `GenericEnumSerializer` reads `@SerialName` through `getDeclaredField`, and builds its name map from `getEnumConstants()` — which ART implements by invoking the enum's static `values()`. Building without AGP's default rules showed `Gender.values()` being stripped; it is retained now. The library no longer borrows that rule from the app's `proguardFiles`.

## Second commit: `.npmignore`

Unrelated to #438 but found while verifying that the new file actually ships. `!**/*.d.ts` makes npm-packlist drop every directory rule preceding it, so `KakaoLoginExample/` and `image/` were packed despite being listed — the published 6.0.3 tarball carries 81 `KakaoLoginExample/*` entries including a 600 kB `yarn.lock`. Dropping the `**/` prefix fixes it while still re-including nested declarations (verified for `src/types/*.d.ts` and `plugins/android/*.d.ts`). `npm pack --dry-run`: 129 files → 38.

## Not covered

No on-device run. `KakaoLoginExample` is RN 0.70.1 / AGP 7.2.1 and cannot build this library (compileSdk 36, Kotlin 2.1.20), so verification stops at R8 output inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Android consumers now receive the required code-shrinking configuration automatically, improving compatibility with release builds using ProGuard or R8.
  - Added safeguards for Kakao Login, Retrofit, and related integrations to help prevent runtime issues after optimization.
  - Package contents now exclude unnecessary Android build artifacts.

- **Documentation**
  - Updated Android and Expo setup guidance to reflect automatic configuration.
  - Clarified when manual file copying is required for projects without autolinking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->